### PR TITLE
First step to integrating queue client with processor

### DIFF
--- a/bin/zambeze-agent
+++ b/bin/zambeze-agent
@@ -9,7 +9,9 @@
 import logging
 import typer
 import pathlib
+import os
 
+from datetime import datetime
 from zambeze.orchestration.agent.agent import Agent
 
 agent_state = {"conf_file": None}
@@ -28,6 +30,12 @@ def start(
     """
     Start the agent (set logger and ZMQ ports).
     """
+
+    # If no log path is specified use default location and type
+    if "".__eq__(log_path):
+        print("Log path was not specified using default.")
+        fmt_str = datetime.now().strftime("%Y_%m_%d-%H_%M_%S_%f")[:-3]
+        log_path = os.path.expanduser('~') + f"/.zambeze/logs/" + fmt_str + ".log"
 
     print(f"Log path: {log_path}")
     agent_logger = logging.getLogger('agent')

--- a/examples/imagemagick-globus.py
+++ b/examples/imagemagick-globus.py
@@ -35,14 +35,7 @@ activity = ShellActivity(
         for i in range(1, 11)
     ],
     command="convert",
-    arguments=[
-        "-delay",
-        "20",
-        "-loop",
-        "0",
-        "/tmp/*.jpg",
-        "a.gif",
-    ],
+    arguments=["-delay", "20", "-loop", "0", "/tmp/*.jpg", "a.gif"],
     logger=logger,
     # Uncomment if running on M1 Mac.
     env_vars=[("PATH", "$PATH:/opt/homebrew/bin")],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+datetime
 globus_sdk>=3.9
 nats-py>=2.1.0
-requests
 pytest>=6.2.4
+pytest-asyncio>=0.19.0
 pyyaml>=5.4.1
 pyzmq>=23.2.0
+requests
 setuptools>=49.3.1
 typer>=0.4.2
-pytest-asyncio>=0.19.0

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -99,11 +99,7 @@ def test_rsync_plugin_check():
                 "user": current_user,
                 "path": current_valid_path,
             },
-            "destination": {
-                "ip": neighbor_vm_ip,
-                "user": "cades",
-                "path": "/tmp",
-            },
+            "destination": {"ip": neighbor_vm_ip, "user": "cades", "path": "/tmp"},
             "arguments": ["-a"],
         }
     }
@@ -167,11 +163,7 @@ def test_rsync_plugin_run():
     arguments = {
         "transfer": {
             "source": {"ip": local_ip, "user": current_user, "path": file_path},
-            "destination": {
-                "ip": neighbor_vm_ip,
-                "user": "cades",
-                "path": "/tmp",
-            },
+            "destination": {"ip": neighbor_vm_ip, "user": "cades", "path": "/tmp"},
             "arguments": ["-a"],
         }
     }

--- a/zambeze/orchestration/agent/agent.py
+++ b/zambeze/orchestration/agent/agent.py
@@ -14,7 +14,8 @@ import zmq
 
 from typing import Optional
 from uuid import uuid4
-from ..processor import Processor, MessageType
+from ..processor import Processor
+from ..zambeze_types import ChannelType
 from ...campaign.activities.abstract_activity import Activity, ActivityStatus
 from ...settings import ZambezeSettings
 
@@ -78,6 +79,6 @@ class Agent:
         """
         self._logger.error("Received activity for dispatch...")
         asyncio.run(
-            self.processor.send(MessageType.COMPUTE.value, activity.generate_message())
+            self.processor.send(ChannelType.ACTIVITY, activity.generate_message())
         )
         activity.status = ActivityStatus.QUEUED

--- a/zambeze/orchestration/processor.py
+++ b/zambeze/orchestration/processor.py
@@ -49,10 +49,11 @@ class Processor(threading.Thread):
             logging.getLogger(__name__) if logger is None else logger
         )
 
+        print(self._settings.settings)
         factory = QueueFactory()
         args = {
-            "ip": self.settings["nats"]["host"],
-            "port": self.settings["nats"]["port"]
+            "ip": self._settings.settings["nats"]["host"],
+            "port": self._settings.settings["nats"]["port"]
         }
         self._queue_client = factory.create(QueueType.NATS, args)
 

--- a/zambeze/orchestration/processor.py
+++ b/zambeze/orchestration/processor.py
@@ -11,23 +11,16 @@ import getpass
 import json
 import logging
 import pathlib
-#import nats
+
 import os
 import socket
 import threading
 
-from enum import Enum
-# from nats.errors import TimeoutError
 from typing import Optional
 from urllib.parse import urlparse
 from ..settings import ZambezeSettings
 from .zambeze_types import ChannelType, QueueType
 from .queue.queue_factory import QueueFactory
-
-# class MessageType(Enum):
-#    COMPUTE = "z_compute"
-#    DATA = "z_data"
-#    STATUS = "z_status"
 
 
 class Processor(threading.Thread):
@@ -52,7 +45,7 @@ class Processor(threading.Thread):
         factory = QueueFactory(logger=self._logger)
         args = {
             "ip": self._settings.settings["nats"]["host"],
-            "port": self._settings.settings["nats"]["port"]
+            "port": self._settings.settings["nats"]["port"],
         }
         self._queue_client = factory.create(QueueType.NATS, args)
 
@@ -65,7 +58,8 @@ class Processor(threading.Thread):
         Evaluate and process messages if requested activity is supported.
         """
         self._logger.debug(
-            f"Connecting to Queue ({self._queue_client.type}) server: {self._queue_client.type}"
+            f"Connecting to Queue ({self._queue_client.type}) server: "
+            f"{self._queue_client.type}"
         )
 
         await self._queue_client.connect()
@@ -107,8 +101,6 @@ class Processor(threading.Thread):
 
                 self._logger.debug("Waiting for messages")
 
-            # except TimeoutError:
-            #    pass
             except Exception as e:
                 print(e)
                 exit(1)
@@ -209,10 +201,8 @@ class Processor(threading.Thread):
                     raise Exception("Needs to be implemented.")
 
             elif file_url.scheme == "rsync":
-                #await self.send(
-                #    MessageType.COMPUTE.value,
                 await self._queue_client.send(
-                        ChannelType.ACTIVITY,
+                    ChannelType.ACTIVITY,
                     {
                         "plugin": "rsync",
                         "cmd": [
@@ -246,13 +236,10 @@ class Processor(threading.Thread):
         :type body: dict
         """
         self._logger.debug(
-            f"Connecting to Queue ({self._queue_client.type}) server: {self._queue_client.uri}"
+            f"Connecting to Queue ({self._queue_client.type}) "
+            f"server: {self._queue_client.uri}"
         )
-        self._logger.debug(f"Sending a 'channel_type.value}' message")
+        self._logger.debug(f"Sending a '{channel_type.value}' message")
 
         await self._queue_client.connect()
         await self._queue_client.send(channel_type, body)
-        #await self._queue_client.close()
-        #nc = await nats.connect(self._settings.get_nats_connection_uri())
-        #await nc.publish(type, json.dumps(body).encode())
-        #await nc.drain()

--- a/zambeze/orchestration/queue/queue_factory.py
+++ b/zambeze/orchestration/queue/queue_factory.py
@@ -47,7 +47,7 @@ class QueueFactory:
         >>>     await client.connect()
         """
         if queue_type == QueueType.NATS:
-            return QueueNATS(args, self._logger)
+            return QueueNATS(args, logger=self._logger)
         elif queue_type == QueueType.RABBITMQ:
             raise Exception(
                 "RabbitMQ queue client has not yet been implemented: "

--- a/zambeze/orchestration/queue/queue_nats.py
+++ b/zambeze/orchestration/queue/queue_nats.py
@@ -69,7 +69,7 @@ class QueueNATS(AbstractQueue):
                 disconnected_cb=self.__disconnected,
                 connect_timeout=1,
             )
-        except:
+        except Exception:
             self._logger.debug(
                 f"Unable to connect to nats server at {self.uri}"
                 "1. Make sure your firewall ports are open.\n"
@@ -107,8 +107,9 @@ class QueueNATS(AbstractQueue):
 
     async def subscribe(self, channel: ChannelType):
         if self._nc is None:
-            raise Exception("Cannot subscribe to topic, client is not "
-                            "connected to a NATS queue")
+            raise Exception(
+                "Cannot subscribe to topic, client is not " "connected to a NATS queue"
+            )
         self._sub[channel] = await self._nc.subscribe(channel.value)
 
     async def unsubscribe(self, channel: ChannelType):
@@ -148,8 +149,10 @@ class QueueNATS(AbstractQueue):
 
     async def send(self, channel: ChannelType, body: dict):
         if self._nc is None:
-            raise Exception("Cannot send message to NATS, client is "
-                            "not connected to a NATS queue")
+            raise Exception(
+                "Cannot send message to NATS, client is "
+                "not connected to a NATS queue"
+            )
         await self._nc.publish(channel.value, json.dumps(body).encode())
 
     async def close(self):

--- a/zambeze/orchestration/queue/queue_nats.py
+++ b/zambeze/orchestration/queue/queue_nats.py
@@ -62,17 +62,28 @@ class QueueNATS(AbstractQueue):
         return self._nc is not None
 
     async def connect(self) -> (bool, str):
-        self._nc = await nats.connect(
-            self.uri,
-            reconnected_cb=self.__reconnected,
-            disconnected_cb=self.__disconnected,
-            connect_timeout=1,
-        )
+        try:
+            self._nc = await nats.connect(
+                self.uri,
+                reconnected_cb=self.__reconnected,
+                disconnected_cb=self.__disconnected,
+                connect_timeout=1,
+            )
+        except:
+            self._logger.debug(
+                f"Unable to connect to nats server at {self.uri}"
+                "1. Make sure your firewall ports are open.\n"
+                "2. That the nats service is up and running.\n"
+                "3. The correct ip address and port have been specified.\n"
+                "4. That an agent.yaml file exists for the zambeze agent.\n"
+            )
+            self._nc = None
+
         if self.connected:
             return (True, f"Able to connect to NATS machine at {self.uri}")
         return (
             False,
-            "Connection attempt timed out while tryint to connect to NATS "
+            "Connection attempt timed out while trying to connect to NATS "
             f"at {self.uri}",
         )
 

--- a/zambeze/settings.py
+++ b/zambeze/settings.py
@@ -7,6 +7,7 @@
 # it under the terms of the MIT License.
 
 import logging
+import os
 import pathlib
 import yaml
 
@@ -58,7 +59,10 @@ class ZambezeSettings:
                 self._conf_file.touch()
                 default_settings = {
                     "nats": {"host": "127.0.0.1", "port": 4222},
-                    "plugins": {"shell": {"config": {}}},
+                    "plugins": {
+                        "shell": {"config": {}},
+                        "All": { "default_working_directory": os.path.expanduser('~') }
+                        },
                     "zmq": {"host": "127.0.0.1", "port": 5555},
                 }
                 with open(self._conf_file, "w") as f:
@@ -71,11 +75,15 @@ class ZambezeSettings:
         with open(self._conf_file, "r") as cf:
             self.settings.update(yaml.safe_load(cf))
 
+        # Ideally the plugin modules would have the default settings located
+        # in their files and they could just be asked here.
         self.__set_default("host", "127.0.0.1", self.settings["nats"])
         self.__set_default("port", 4222, self.settings["nats"])
         self.__set_default("host", "127.0.0.1", self.settings["zmq"])
         self.__set_default("port", 5555, self.settings["zmq"])
-        self.__set_default("plugins", {}, self.settings)
+        self.__set_default("plugins", { "All": {}}, self.settings)
+        self.__set_default("All", {}, self.settings["plugins"])
+        self.__set_default("default_working_directory", os.path.expanduser('~'), self.settings["plugins"]["All"])
         self.__save()
 
         self.__configure_plugins()

--- a/zambeze/settings.py
+++ b/zambeze/settings.py
@@ -94,16 +94,16 @@ class ZambezeSettings:
 
         self.plugins.configure(config=config)
 
-    def get_nats_connection_uri(self) -> str:
-        """
-        Get the NATS connection URI.
-
-        :return: NATS connection URI
-        :rtype: str
-        """
-        host = self.settings["nats"]["host"]
-        port = self.settings["nats"]["port"]
-        return f"nats://{host}:{port}"
+#    def get_nats_connection_uri(self) -> str:
+#        """
+#        Get the NATS connection URI.
+#
+#        :return: NATS connection URI
+#        :rtype: str
+#        """
+#        host = self.settings["nats"]["host"]
+#        port = self.settings["nats"]["port"]
+#        return f"nats://{host}:{port}"
 
     def get_zmq_connection_uri(self) -> str:
         """

--- a/zambeze/settings.py
+++ b/zambeze/settings.py
@@ -61,8 +61,8 @@ class ZambezeSettings:
                     "nats": {"host": "127.0.0.1", "port": 4222},
                     "plugins": {
                         "shell": {"config": {}},
-                        "All": { "default_working_directory": os.path.expanduser('~') }
-                        },
+                        "All": {"default_working_directory": os.path.expanduser("~")},
+                    },
                     "zmq": {"host": "127.0.0.1", "port": 5555},
                 }
                 with open(self._conf_file, "w") as f:
@@ -81,9 +81,13 @@ class ZambezeSettings:
         self.__set_default("port", 4222, self.settings["nats"])
         self.__set_default("host", "127.0.0.1", self.settings["zmq"])
         self.__set_default("port", 5555, self.settings["zmq"])
-        self.__set_default("plugins", { "All": {}}, self.settings)
+        self.__set_default("plugins", {"All": {}}, self.settings)
         self.__set_default("All", {}, self.settings["plugins"])
-        self.__set_default("default_working_directory", os.path.expanduser('~'), self.settings["plugins"]["All"])
+        self.__set_default(
+            "default_working_directory",
+            os.path.expanduser("~"),
+            self.settings["plugins"]["All"],
+        )
         self.__save()
 
         self.__configure_plugins()
@@ -102,16 +106,16 @@ class ZambezeSettings:
 
         self.plugins.configure(config=config)
 
-#    def get_nats_connection_uri(self) -> str:
-#        """
-#        Get the NATS connection URI.
-#
-#        :return: NATS connection URI
-#        :rtype: str
-#        """
-#        host = self.settings["nats"]["host"]
-#        port = self.settings["nats"]["port"]
-#        return f"nats://{host}:{port}"
+    #    def get_nats_connection_uri(self) -> str:
+    #        """
+    #        Get the NATS connection URI.
+    #
+    #        :return: NATS connection URI
+    #        :rtype: str
+    #        """
+    #        host = self.settings["nats"]["host"]
+    #        port = self.settings["nats"]["port"]
+    #        return f"nats://{host}:{port}"
 
     def get_zmq_connection_uri(self) -> str:
         """


### PR DESCRIPTION
This pr replaces the direct calls to the nats queue with an abstract queue_client layer in the processor.py file.