### PR TITLE
Remove call to non existent settings object

### DIFF
--- a/zambeze/orchestration/queue/queue_nats.py
+++ b/zambeze/orchestration/queue/queue_nats.py
@@ -27,13 +27,13 @@ class QueueNATS(AbstractQueue):
     async def __disconnected(self):
         if self._logger:
             self._logger.info(
-                f"Disconnected from nats... {self._settings.get_nats_connection_uri()}"
+                f"Disconnected from nats... {self.uri}"
             )
 
     async def __reconnected(self):
         if self._logger:
             self._logger.info(
-                f"Reconnected to nats... {self._settings.get_nats_connection_uri()}"
+                f"Reconnected to nats... {self.uri}"
             )
 
     @property


### PR DESCRIPTION
nats queue was calling a method from _settings object that was non-existent in logger. 

This in response to getting devel merged into main.

Estimated time: 30 minutes