### PR TITLE
Change name from build to type-check

### DIFF
--- a/.github/workflows/pyre-check.yml
+++ b/.github/workflows/pyre-check.yml
@@ -3,7 +3,7 @@ name: Pyre
 on: [push]
 
 jobs:
-  build:
+  type-check:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Clarify the name of the job instead of build change to type-check.