### PR TITLE
Add pylint check to enforce pep8

### DIFF
--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -1,0 +1,24 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint==2.16.1
+        pip install -r requirements.txt
+    - name: Analysing the code with pylint
+      run: |
+        pylint --recursive=y --disable=missing-module-docstring --disable=missing-class-docstring --disable=missing-function-docstring .

--- a/.github/workflows/pyre-check.yml
+++ b/.github/workflows/pyre-check.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyre-check==0.9.17 watchman
         pip install -r requirements.txt
-    - name: Analysing the code with pylint
+    - name: Analysing the code with pyre
       run: |
         pyre --search-path $(python -c 'import site; print(site.getsitepackages()[0])') --search-path $(python -m pip show pip | grep Location | awk '{print $2}') --search-path . --source-directory zambeze check
         pyre --search-path $(python -c 'import site; print(site.getsitepackages()[0])') --search-path $(python -m pip show pip | grep Location | awk '{print $2}') --search-path . --source-directory tests check


### PR DESCRIPTION
Style guidelines associated with pep8 i.e. class methods were not being enforced with other checks. I.e. using snake_case instead of camel case. Adding pylint to help enforce these. Ignoring Docstring complaints at this point.

Estimated time: 1h
Actual time: 30 min