### PR TITLE
Fix module import issue

### DIFF
--- a/tests/test_common_plugin_functions.py
+++ b/tests/test_common_plugin_functions.py
@@ -1,0 +1,23 @@
+# Local imports
+from zambeze.orchestration.plugin_modules.common_plugin_functions import (
+    registerPlugins
+)
+
+# Standard imports
+import os
+import pytest
+import uuid
+
+
+@pytest.mark.unit
+def test_registerPlugins():
+
+    plugins = registerPlugins()
+    assert len(plugins) > 0
+
+    for plugin in plugins:
+        # Lets make sure we don't import system plugins i.e. git.cmd we will
+        # do this by assuming we should only be importing plugins that are flat
+        # and are not nested 'git' is valid 'git.something' is not
+        assert '.' not in plugin
+

--- a/zambeze/orchestration/plugin_modules/common_plugin_functions.py
+++ b/zambeze/orchestration/plugin_modules/common_plugin_functions.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import logging
+import os
 import pkgutil
 
 
@@ -16,7 +17,8 @@ def registerPlugins(logger: Optional[logging.Logger] = None) -> list:
     module_names = []
     # plugin_path = [str(Path(__file__).resolve().parent) + "/plugin_modules"]
     plugin_path = [str(Path(__file__).resolve().parent)]
-    for importer, module_name, ispkg in pkgutil.walk_packages(path=plugin_path):
+    print(plugin_path)
+    for importer, module_name, ispkg in pkgutil.walk_packages(plugin_path):
         if (
             module_name != "abstract_plugin"
             and module_name != "__init__"
@@ -27,7 +29,13 @@ def registerPlugins(logger: Optional[logging.Logger] = None) -> list:
             and module_name != "abstract_uri_separator"
             and module_name != "file_uri_separator"
         ):
-            module_names.append(module_name)
+
+            module_path = module_name.replace('.', os.path.sep)
+            full_module_path = os.path.join(plugin_path[0], module_path)
+            # Make sure we are only grabbing zambeze plugins and not modules
+            # from elsewhere in the Python path
+            if os.path.isdir(full_module_path):
+                module_names.append(module_name)
     if logger:
         logger.debug(f"Registered Plugins: {', '.join(module_names)}")
     return module_names


### PR DESCRIPTION
Fixes an issue with system plugins being registered when we just wanted to import zambeze plugins from the plugins_module in zambeze. 

Error message below.

```bash
tests/test_activity_shell.py:40:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/campaign/activities/shell.py:76: in generate_message
    factory = MessageFactory(logger=self.logger)
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
______________________________________________________________________________ test_factory_fail _______________________________________________________________________________

    @pytest.mark.unit
    def test_factory_fail():
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:15:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
_________________________________________________________________ test_factory_activity_template_plugin_globus _________________________________________________________________

    @pytest.mark.unit
    def test_factory_activity_template_plugin_globus():
        """This test should be true all required fields are defined as well as all
        optional fields"""
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:63:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
_________________________________________________________________ test_factory_activity_template_plugin_rsync __________________________________________________________________

    @pytest.mark.unit
    def test_factory_activity_template_plugin_rsync():
        """This test should be true all required fields are defined as well as all
        optional fields"""
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:95:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
_____________________________________________________________________ test_factory_activity_template_shell _____________________________________________________________________

    @pytest.mark.unit
    def test_factory_activity_template_shell():
        """This test should be true all required fields are defined as well as all
        optional fields"""
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:129:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
_________________________________________________________________________ test_factory_success_status __________________________________________________________________________

    @pytest.mark.unit
    def test_factory_success_status():
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:154:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
_______________________________________________________________________ test_factory_create_plugin_rsync _______________________________________________________________________

    @pytest.mark.unit
    def test_factory_create_plugin_rsync():
        """This test should be true all required fields are defined as well as all
        optional fields"""
        logger = logging.getLogger(__name__)
>       msg_factory = MessageFactory(logger)

tests/test_message_factory.py:199:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
___________________________________________________________________________ test_shell_plugin_check ____________________________________________________________________________

    @pytest.mark.unit
    def test_shell_plugin_check():
        plugins = Plugins()
        plugins.configure({"shell": {}})

        file_name = "shell_file.txt1"
        current_valid_path = os.getcwd()
        file_path = current_valid_path + "/" + file_name
        original_number = random.randint(0, 100000000000)

>       factory = MessageFactory(logger=logger)

tests/test_plugins.py:93:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
____________________________________________________________________________ test_shell_plugin_run _____________________________________________________________________________

    @pytest.mark.unit
    def test_shell_plugin_run():
        plugins = Plugins()
        plugins.configure({"shell": {}})

        file_name = "shell_file2.txt"
        current_valid_path = os.getcwd()
        file_path = current_valid_path + "/" + file_name
        original_number = random.randint(0, 100000000000)

>       factory = MessageFactory(logger=logger)

tests/test_plugins.py:125:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
zambeze/orchestration/message/message_factory.py:27: in __init__
    self._plugins_msg_template_generators = PluginsMessageTemplateEngine(logger)
zambeze/orchestration/plugins_message_template_engine.py:21: in __init__
    self.__registerPluginTemplateGenerators()
zambeze/orchestration/plugins_message_template_engine.py:28: in __registerPluginTemplateGenerators
    module = import_module(
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:972: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'zambeze.orchestration.plugin_modules.git.cmd', import_ = <function _gcd_import at 0x7ff0bdf0b310>

>   ???
E   ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'

<frozen importlib._bootstrap>:984: ModuleNotFoundError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
['git', 'git.cmd', 'git.compat', 'git.config', 'git.db', 'git.diff', 'git.exc', 'git.index', 'git.index.base', 'git.index.fun', 'git.index.typ', 'git.index.util', 'git.objects', 'git.objects.base', 'git.objects.blob', 'git.objects.commit', 'git.objects.fun', 'git.objects.submodule', 'git.objects.submodule.base', 'git.objects.submodule.root', 'git.objects.submodule.util', 'git.objects.tag', 'git.objects.tree', 'git.objects.util', 'git.refs', 'git.refs.head', 'git.refs.log', 'git.refs.reference', 'git.refs.remote', 'git.refs.symbolic', 'git.refs.tag', 'git.remote', 'git.repo', 'git.repo.base', 'git.repo.fun', 'git.types', 'git.util', 'globus', 'rsync', 'shell']
git
 - Registering plugin template generator: gitmessagetemplategenerator
Attribute nameis GitMessageTemplateGenerator
git.cmd
=========================================================================== short test summary info ============================================================================
FAILED tests/test_activity_shell.py::test_shell_activity_generate_message - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_fail - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_activity_template_plugin_globus - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_activity_template_plugin_rsync - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_activity_template_shell - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_success_status - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_message_factory.py::test_factory_create_plugin_rsync - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_plugins.py::test_shell_plugin_check - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
FAILED tests/test_plugins.py::test_shell_plugin_run - ModuleNotFoundError: No module named 'zambeze.orchestration.plugin_modules.git.cmd'
```