### PR TITLE
Fix small issue with uri separator not doing better checking of format

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,4 +30,4 @@ test-zambeze-globus:
     - python3.9 -m pip install .
     - python3.9 -m pytest -m globus -sv
     - echo "globus.token file must exist already to prevent hanging"
-    - python3.9 -m pytest -m globus_manual -sv
+    - python3.9 -m pytest -m globus_native -sv

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,4 @@ markers =
     gitlab_runner: Mark a test that should only be run in the context of the gitlabrunner
     globus: Mark a test that should only be run in the context of a globus connect server, the server should exist and be running on the same machine
     globus_native: Mark a test that should only be run in the context of a globus connect server and run manually because of the native auth flow
+    nats: Mark a test that uses nats, nats is not currently supported but the infrastructure has been kept these tests are turned off by default 

--- a/tests/test_globus_uri_separator.py
+++ b/tests/test_globus_uri_separator.py
@@ -153,6 +153,3 @@ def test_globus_uri_separator9():
     result = separator.separate(uri, default_uuid)
 
     assert len(result["error_message"]) > 0
-
-
-

--- a/tests/test_globus_uri_separator.py
+++ b/tests/test_globus_uri_separator.py
@@ -139,3 +139,20 @@ def test_globus_uri_separator8():
     assert result["path"] == "/"
     assert result["file_name"] == file_name
     assert len(result["error_message"]) == 0
+
+
+@pytest.mark.unit
+def test_globus_uri_separator9():
+    separator = GlobusURISeparator()
+    # "globus://XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXfile.txt"
+    valid_uuid = str(uuid.uuid4())
+    default_uuid = str(uuid.uuid4())
+    file_path = ""
+    file_name = "file.txt"
+    uri = "globus://" + valid_uuid + file_path + file_name
+    result = separator.separate(uri, default_uuid)
+
+    assert len(result["error_message"]) > 0
+
+
+

--- a/tests/test_plugin_globus.py
+++ b/tests/test_plugin_globus.py
@@ -625,7 +625,7 @@ def test_globus_process_native():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[1])
+                        + os.getenv(required_env_variables[1]) + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"

--- a/tests/test_plugin_globus.py
+++ b/tests/test_plugin_globus.py
@@ -349,7 +349,7 @@ def test_globus_process():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[2])
+                        + os.getenv(required_env_variables[2]) + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"
@@ -386,12 +386,11 @@ def test_globus_process():
         os.remove(abs_path_destination_shared)
 
     checked_items = globus_plugin.check(package)
+    print(checked_items)
     all_checks_pass = True
     for item in checked_items:
         for action in item.keys():
             if not item[action][0]:
-                print("Something went wrong.")
-                print(item[action][1])
                 all_checks_pass = False
 
     if all_checks_pass:
@@ -484,7 +483,7 @@ def test_globus_process_async():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[2])
+                        + os.getenv(required_env_variables[2]) + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"
@@ -523,6 +522,7 @@ def test_globus_process_async():
         os.remove(abs_path_destination_shared)
 
     checked_actions = globus_plugin.check(package)
+    print(checked_actions)
     for item in checked_actions:
         for action in item.keys():
             assert item[action][0]
@@ -666,7 +666,6 @@ def test_globus_process_native():
     print(checked_items)
     for item in checked_items:
         for action in item.keys():
-            print(item[action])
             if not item[action][0]:
                 all_checks_pass = False
 

--- a/tests/test_plugin_globus.py
+++ b/tests/test_plugin_globus.py
@@ -344,7 +344,8 @@ def test_globus_process():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[2]) + os.sep
+                        + os.getenv(required_env_variables[2])
+                        + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"
@@ -477,7 +478,8 @@ def test_globus_process_async():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[2]) + os.sep
+                        + os.getenv(required_env_variables[2])
+                        + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"
@@ -618,7 +620,8 @@ def test_globus_process_native():
                 "items": [
                     {
                         "source": "globus://"
-                        + os.getenv(required_env_variables[1]) + os.sep
+                        + os.getenv(required_env_variables[1])
+                        + os.sep
                         + sub_folder
                         + file_name,
                         "destination": "globus://"

--- a/tests/test_queue_nats.py
+++ b/tests/test_queue_nats.py
@@ -9,13 +9,13 @@ import pytest
 import random
 
 
-@pytest.mark.unit
+@pytest.mark.nats
 def test_queue_nats_type():
     queue = QueueNATS({})
     assert queue.type == QueueType.NATS
 
 
-@pytest.mark.unit
+@pytest.mark.nats
 def test_queue_nats_uri():
     queue = QueueNATS({})
     assert queue.uri == "nats://127.0.0.1:4222"
@@ -27,7 +27,7 @@ def test_queue_nats_uri():
     assert queue.uri == f"nats://{config['ip']}:{config['port']}"
 
 
-@pytest.mark.unit
+@pytest.mark.nats
 def test_queue_nats_connected():
     queue = QueueNATS({})
     assert queue.uri == "nats://127.0.0.1:4222"
@@ -49,7 +49,7 @@ async def queue_nats_connect_close(config):
     assert queue.connected is False
 
 
-@pytest.mark.gitlab_runner
+@pytest.mark.nats
 def test_queue_nats_connect_close():
     config = {}
     config["ip"] = os.getenv("ZAMBEZE_CI_TEST_NATS_IP")
@@ -72,7 +72,7 @@ async def queue_nats_subscribe(config):
     assert queue.subscriptions[0] == ChannelType.ACTIVITY
 
 
-@pytest.mark.gitlab_runner
+@pytest.mark.nats
 def test_queue_nats_subscribe():
     config = {}
     config["ip"] = os.getenv("ZAMBEZE_CI_TEST_NATS_IP")
@@ -90,7 +90,7 @@ async def queue_nats_send_subscribe_nextMsg(config, original_number):
     await queue.close()
 
 
-@pytest.mark.gitlab_runner
+@pytest.mark.nats
 def test_queue_nats_send_subscribe_nextMsg():
     config = {}
     config["ip"] = os.getenv("ZAMBEZE_CI_TEST_NATS_IP")

--- a/zambeze/orchestration/plugin_modules/globus/globus.py
+++ b/zambeze/orchestration/plugin_modules/globus/globus.py
@@ -439,16 +439,15 @@ class Globus(Plugin):
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["destination"], self.__default_endpoint
             )
-            if globus_sep_uri['error_message']:
-                return (False, "Destination URI - " + globus_sep_uri['error_message'])
+            if globus_sep_uri["error_message"]:
+                return (False, "Destination URI - " + globus_sep_uri["error_message"])
 
         for item in action_package["items"]:
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["source"], self.__default_endpoint
             )
-            if globus_sep_uri['error_message']:
-                return (False, "Source URI - " + globus_sep_uri['error_message'])
-
+            if globus_sep_uri["error_message"]:
+                return (False, "Source URI - " + globus_sep_uri["error_message"])
 
         # Any agent with the globus plugin can submit a job to globus if it
         # has access to the globus cloud
@@ -462,8 +461,8 @@ class Globus(Plugin):
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["destination"], self.__default_endpoint
             )
-            if globus_sep_uri['error_message']:
-                return (False, globus_sep_uri['error_message'])
+            if globus_sep_uri["error_message"]:
+                return (False, globus_sep_uri["error_message"])
 
             if not localEndpointExists(globus_sep_uri["uuid"], self.__endpoints):
                 error_msg = "Invalid source endpoint uuid detected in "
@@ -474,8 +473,8 @@ class Globus(Plugin):
                 return (False, error_msg)
 
             file_sep_uri = self.__file_uri_separator.separate(item["source"])
-            if file_sep_uri['error_message']:
-                return (False, file_sep_uri['error_message'])
+            if file_sep_uri["error_message"]:
+                return (False, file_sep_uri["error_message"])
             file_path = file_sep_uri["path"] + file_sep_uri["file_name"]
             if not exists(file_path):
                 return False, f"Item does not exist {file_path}"
@@ -509,8 +508,8 @@ class Globus(Plugin):
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["source"], self.__default_endpoint
             )
-            if globus_sep_uri['error_message']:
-                return (False, globus_sep_uri['error_message'])
+            if globus_sep_uri["error_message"]:
+                return (False, globus_sep_uri["error_message"])
 
             if not localEndpointExists(globus_sep_uri["uuid"], self.__endpoints):
                 error_msg = "Invalid source endpoint uuid detected in "

--- a/zambeze/orchestration/plugin_modules/globus/globus.py
+++ b/zambeze/orchestration/plugin_modules/globus/globus.py
@@ -284,7 +284,6 @@ class Globus(Plugin):
                     "callback": {"get_task_status": {"task_id": result["task_id"]}},
                     "result": {"status": result["code"], "message": result["message"]},
                 }
-
         return transfer_result
 
     def __runGetTaskStatus(self, action_package: dict):
@@ -438,6 +437,20 @@ class Globus(Plugin):
         >>>     ]
         >>> }
         """
+        for item in action_package["items"]:
+            globus_sep_uri = self.__globus_uri_separator.separate(
+                item["destination"], self.__default_endpoint
+            )
+            if globus_sep_uri['error_message']:
+                return (False, "Destination URI - " + globus_sep_uri['error_message'])
+
+        for item in action_package["items"]:
+            globus_sep_uri = self.__globus_uri_separator.separate(
+                item["source"], self.__default_endpoint
+            )
+            if globus_sep_uri['error_message']:
+                return (False, "Source URI - " + globus_sep_uri['error_message'])
+
 
         # Any agent with the globus plugin can submit a job to globus if it
         # has access to the globus cloud
@@ -451,6 +464,9 @@ class Globus(Plugin):
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["destination"], self.__default_endpoint
             )
+            if globus_sep_uri['error_message']:
+                return (False, globus_sep_uri['error_message'])
+
             if not localEndpointExists(globus_sep_uri["uuid"], self.__endpoints):
                 error_msg = "Invalid source endpoint uuid detected in "
                 error_msg += f"move_from_globus_collection' item: {item}"
@@ -460,6 +476,8 @@ class Globus(Plugin):
                 return (False, error_msg)
 
             file_sep_uri = self.__file_uri_separator.separate(item["source"])
+            if file_sep_uri['error_message']:
+                return (False, file_sep_uri['error_message'])
             file_path = file_sep_uri["path"] + file_sep_uri["file_name"]
             if not exists(file_path):
                 return False, f"Item does not exist {file_path}"
@@ -493,6 +511,9 @@ class Globus(Plugin):
             globus_sep_uri = self.__globus_uri_separator.separate(
                 item["source"], self.__default_endpoint
             )
+            if globus_sep_uri['error_message']:
+                return (False, globus_sep_uri['error_message'])
+
             if not localEndpointExists(globus_sep_uri["uuid"], self.__endpoints):
                 error_msg = "Invalid source endpoint uuid detected in "
                 error_msg += f"'move_from_globus_collection' item: {item} "
@@ -556,15 +577,10 @@ class Globus(Plugin):
         """
         self.__validConfig(config)
 
-        print("Config is")
-        print(config)
         self._logger.debug(json.dumps(config, indent=4))
         if "authentication_flow" in config:
             if "client_id" in config["authentication_flow"]:
                 self.__client_id = config["authentication_flow"]["client_id"]
-
-        print("Client id is ")
-        print(self.__client_id)
 
         # Detect hostname
         self.__hostname = gethostname()

--- a/zambeze/orchestration/plugin_modules/globus/globus_uri_separator.py
+++ b/zambeze/orchestration/plugin_modules/globus/globus_uri_separator.py
@@ -72,9 +72,7 @@ class GlobusURISeparator(URISeparator):
         # Replace multiple occurances of // with single /
         UUID_and_path = re.sub(os.sep + "{2,}", os.sep, UUID_and_path)
 
-        print(f"UUID_and_path is  {UUID_and_path}")
         UUID = UUID_and_path[0:36]
-        print(f"UUID from path is {UUID}")
         file_and_path = UUID_and_path
 
         legal_uuid = default_uuid
@@ -92,6 +90,18 @@ class GlobusURISeparator(URISeparator):
                 return package
             legal_uuid = UUID
             file_and_path = UUID_and_path[36:]
+            if len(file_and_path) > 0:
+                # If actual char in path first char should be a separator
+                if file_and_path[0] is not os.sep:
+                    # This should catch errors like this
+                    # globus://XXXXYYYY-XXXX-XXXX-XXXXYYYYXXXXfilepath/file.txt
+                    # which should instead be
+                    # globus://XXXXYYYY-XXXX-XXXX-XXXXYYYYXXXX/filepath/file.txt
+                    error_msg = f"Malformed Globus URI format detected {uri}"
+                    error_msg += f" expected {os.sep} between UUID and file path"
+                    package["error_message"] = error_msg
+                    return package
+
         else:
             if default_uuid is None:
                 error_msg = f"Incompatible Globus URI format {uri} must contain 36 "


### PR DESCRIPTION
As a part of the pr to debug the ci it was discovered that there was a problem with the URI separator. This has been fixed here. The actual problem with the CI was found to security groups not being correctly set on the VMs after migration.

In addition, the nats tests were failing because they are not setup in the new cloud. I have turned them off because supporting them is not a priority.