### PR TITLE
Use argparse for command line

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - pyzmq
   - requests
   - SQLAlchemy
-  - typer
   - networkx
   - pip
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     entry_points={
         "console_scripts": [
             "zambeze = zambeze.cli:main",
-            "zambeze-agent = zambeze.cli_agent:agent_app",
+            "zambeze-agent = zambeze.cli_agent:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     python_requires=">=3.10",
     entry_points={
         "console_scripts": [
-            "zambeze = zambeze.cli:app",
+            "zambeze = zambeze.cli:main",
             "zambeze-agent = zambeze.cli_agent:agent_app",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     url="https://github.com/ORNL/zambeze",
     packages=find_packages(),
     install_requires=[
-        "typer",
         "pyzmq",
         "dill",
         "networkx",

--- a/zambeze/__init__.py
+++ b/zambeze/__init__.py
@@ -4,12 +4,9 @@
 # it under the terms of the MIT License.
 
 import importlib.metadata
-import logging
 
 from .campaign import Activity, Campaign
 from .campaign.activities import ShellActivity, TransferActivity
-
-logging.getLogger("zambeze").addHandler(logging.StreamHandler())
 
 __author__ = "https://zambeze.org"
 __credits__ = "Oak Ridge National Laboratory"

--- a/zambeze/cli_agent.py
+++ b/zambeze/cli_agent.py
@@ -3,40 +3,33 @@
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the MIT License.
 
+import argparse
 import logging
-import typer
 import pathlib
 
 from zambeze.orchestration.agent.agent import Agent
 
-agent_app = typer.Typer()
 
-
-@agent_app.command()
-def start(
-    log_path: str = typer.Option("", help="Path to logs on disk."),
-    debug: bool = typer.Option(False, help="If debug logs are enabled."),
-    config_path: str = typer.Option(
-        str(pathlib.Path.home().joinpath(".zambeze").joinpath("agent.yaml")),
-        help="Path to config.",
-    ),
-):
+def run_agent(log_path, debug):
     """
-    Start the agent (set logger and ZMQ ports).
+    Run the zambeze agent.
     """
 
-    # Log path comes from agents/commands.py
-    agent_logger = logging.getLogger("agent")
+    # Path for config files
+    config_path = pathlib.Path.home().joinpath(".zambeze").joinpath("agent.yaml")
+
+    # Configure logging
+    agent_logger = logging.getLogger(__name__)
     fh = logging.FileHandler(log_path)
-    formatter = logging.Formatter(
-        "[Zambeze Agent] [%(levelname)s] %(asctime)s - %(message)s"
-    )
-    fh.setFormatter(formatter)
+
+    fmt = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    fh.setFormatter(fmt)
 
     if debug:
         agent_logger.setLevel(logging.DEBUG)
     else:
         agent_logger.setLevel(logging.INFO)
+
     agent_logger.addHandler(fh)
 
     agent_logger.info("*****************************************************")
@@ -47,8 +40,24 @@ def start(
     agent_logger.info(f"Debug Logs:\t\t{debug}")
     agent_logger.info("*****************************************************")
 
-    # Quick fix to address empty string in CL-args.
-    if config_path == "":
-        config_path = None
-
+    # Create an agent
     Agent(conf_file=config_path, logger=agent_logger)
+
+
+def main():
+    """
+    Main entry point for zambeze agent command line interface.
+    """
+
+    # Command line parser for zambeze agent
+    parser = argparse.ArgumentParser(description="Zambeze agent command line interface")
+    parser.add_argument("-lp", "--log-path", help="path to log files")
+    parser.add_argument(
+        "-d", "--debug", action="store_true", help="enable debug log level"
+    )
+    args = parser.parse_args()
+
+    # Get args from command line and run zambeze agent
+    log_path = args.log_path
+    debug = args.debug
+    run_agent(log_path, debug)

--- a/zambeze/cli_agent.py
+++ b/zambeze/cli_agent.py
@@ -35,9 +35,9 @@ def run_agent(log_path, debug):
     agent_logger.info("*****************************************************")
     agent_logger.info("Creating Zambeze agent subprocess with configuration:")
     agent_logger.info("*****************************************************")
-    agent_logger.info(f"Log Path:\t\t{log_path}")
-    agent_logger.info(f"Config Path:\t\t{config_path}")
-    agent_logger.info(f"Debug Logs:\t\t{debug}")
+    agent_logger.info(f"Log Path:     {log_path}")
+    agent_logger.info(f"Config Path:  {config_path}")
+    agent_logger.info(f"Debug Logs:   {debug}")
     agent_logger.info("*****************************************************")
 
     # Create an agent


### PR DESCRIPTION
This removes the typer dependency and uses argparse from Python's standard library for the zambeze command line interface (CLI). The zambeze agent is now run with `zambeze start`, stopped with `zambeze stop`, and status is shown with `zambeze status`. This also closes issue #160.