### PR TITLE
Add logging utility for agent

### DIFF
--- a/docs/source/get-started/logging.rst
+++ b/docs/source/get-started/logging.rst
@@ -1,0 +1,21 @@
+Logging
+=======
+
+The Zambeze agent runs as a daemon process and logs messages to a log file. The log file records information about the agent's activities, and it can be used for debugging and monitoring.
+Zambeze provides a logging utility to view the log file and supports ``--mode``, ``--numlines``, and ``--follow`` options:
+
+.. code-block:: text
+
+    zambeze logs
+    zambeze logs --mode head
+    zambeze logs --mode tail --numlines 20
+
+Defaults to ``tail`` mode with ``10`` lines. Doesn't support negative integers, which results in no lines logged. 
+
+The ``--follow / -f`` option can be used for continuous monitoring while in ``tail`` mode:
+
+.. code-block:: text
+
+    zambeze logs --f
+    zambeze logs --mode tail --follow
+    zambeze logs --mode tail --numlines 20 --follow

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ The source code for zambeze is available on `GitHub <https://github.com/ORNL/zam
    get-started/installation
    get-started/usage
    get-started/contributing
+   get-started/logging
 
 .. toctree::
    :caption: Examples

--- a/src/zambeze/cli.py
+++ b/src/zambeze/cli.py
@@ -146,10 +146,15 @@ def logs(mode, num_lines, follow=False):
     follow : bool
         Boolean whether to follow the log file. Available only in the 'tail' mode.
     """
+
+    # Head mode does not support following logs
+    if mode == "head" and follow:
+        logger.info("Cannot follow logs in head mode. Exiting...")
+        return
+
     state_path = pathlib.Path.home() / ".zambeze/agent.state"
     if not state_path.is_file():
-        msg = "Agent does not exist, start an agent with `zambeze start`"
-        logger.info(msg)
+        logger.info("Agent does not exist, start an agent with `zambeze start`")
         return
 
     with state_path.open("r") as f:
@@ -259,10 +264,6 @@ def main():
     elif args.command == "status":
         status()
     elif args.command == "logs":
-        # Head mode does not support following logs
-        if args.mode == "head" and args.follow:
-            print("Cannot follow logs in head mode. Exiting...")
-        else:
-            logs(args.mode, args.numlines, args.follow)
+        logs(args.mode, args.numlines, args.follow)
     else:
         print("Use \33[32mzambeze --help\33[0m for zambeze agent commands")


### PR DESCRIPTION
The commit adds a logging utility to Zambeze agent as requested in #127. This allows using `head/tail` modes with `numlines`.

For example:
```
zambeze logs
zambeze logs --mode=head
zambeze logs --mode=tail --numlines=20
```

Defaults to `tail` mode with `10` lines. Doesn't support negative integers, which results in no lines logged.

This is tested with a 1G text file and the utility attempts to efficiently `head/tail` logs.