### PR TITLE
Track new logs upon agent restarts

### DIFF
--- a/docs/source/get-started/logging.rst
+++ b/docs/source/get-started/logging.rst
@@ -1,8 +1,7 @@
 Logging
 =======
 
-The Zambeze agent runs as a daemon process and logs messages to a log file. The log file records information about the agent's activities, and it can be used for debugging and monitoring.
-Zambeze provides a logging utility to view the log file and supports ``--mode``, ``--numlines``, and ``--follow`` options:
+The Zambeze agent runs as a daemon process and logs messages to a log file. The log file records information about the agent's activities, and it can be used for debugging and monitoring. Zambeze provides a logging utility to view the log file and supports ``--mode``, ``--numlines``, and ``--follow`` options:
 
 .. code-block:: text
 
@@ -10,12 +9,12 @@ Zambeze provides a logging utility to view the log file and supports ``--mode``,
     zambeze logs --mode head
     zambeze logs --mode tail --numlines 20
 
-Defaults to ``tail`` mode with ``10`` lines. Doesn't support negative integers, which results in no lines logged. 
+The logger defaults to ``tail`` mode with ``10`` lines and it doesn't support negative integers, which results in no lines logged. 
 
-The ``--follow / -f`` option can be used for continuous monitoring while in ``tail`` mode:
+The ``--follow / -f`` option can be used for continuous monitoring while in ``tail`` mode. The utility automatically tracks the agent's logs upon restarts, ensuring that the most recent log is always available without needing to restart the logging process:
 
 .. code-block:: text
 
-    zambeze logs --f
+    zambeze logs -f
     zambeze logs --mode tail --follow
     zambeze logs --mode tail --numlines 20 --follow

--- a/src/zambeze/cli.py
+++ b/src/zambeze/cli.py
@@ -178,6 +178,7 @@ def logs(mode, num_lines, follow=False):
             mlog_file, err_msg = _get_log_file(mlog_path)
             if err_msg:
                 return False, err_msg
+            state["log_handle"].close()
             state["log_handle"] = open(mlog_file, "rb")
             state["log_path"] = mlog_path
             return True, None
@@ -228,7 +229,6 @@ def logs(mode, num_lines, follow=False):
                                 logger.error(err_msg)
                                 break
                             if path_change:
-                                lf.close()
                                 lf = state["log_handle"]
 
                         line = lf.readline()

--- a/src/zambeze/cli.py
+++ b/src/zambeze/cli.py
@@ -20,7 +20,19 @@ logger = logging.getLogger(__name__)
 
 
 def _get_log_file(log_path):
-    # Given a log path, returns the corresponding log file if it exists
+    """Gets a PurePath object for the log path if it exists.
+
+    Parameters
+    ----------
+    log_path : str
+        Path to the log file.
+
+    Returns
+    -------
+    tuple
+        The first element is a pathlib.Path object if the log file exists, the second element
+        is an error message if the log path is invalid.
+    """
     log_file = pathlib.Path(log_path) if log_path else None
     if not log_file or not log_file.is_file():
         return (
@@ -31,8 +43,25 @@ def _get_log_file(log_path):
 
 
 def _valid_follow(state, new_state):
-    # Checks if the log path has changed in the agent's new state and updates the log handle if so. Otherwise, it is
-    # an invalid follow
+    """Checks if the log path has changed in the agent's state and is a valid path.
+
+    The state of the agent updates on events like agent restarts, and the log path may change. If there is
+    a change, we need to verify that the new path is valid so that we can safely follow the new log file.
+    Otherwise, it is an invalid follow.
+
+    Parameters
+    ----------
+    state : dict
+        The current state of the agent.
+    new_state : dict
+        The updated state of the agent.
+
+    Returns
+    -------
+    tuple
+        The first element is a boolean indicating whether the log path has changed and is valid,
+        the second element is an error message if the new state is invalid.
+    """
     mlog_path = new_state.get("log_path")
     if mlog_path != state.get("log_path"):
         mlog_file, err_msg = _get_log_file(mlog_path)

--- a/src/zambeze/cli.py
+++ b/src/zambeze/cli.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_log_file(log_path):
-    """Gets a PurePath object for the log path if it exists.
+    """Get a PurePath object for the log path if it exists.
 
     Parameters
     ----------
@@ -43,7 +43,7 @@ def _get_log_file(log_path):
 
 
 def _valid_follow(state, new_state):
-    """Checks if the log path has changed in the agent's state and is a valid path.
+    """Check if the log path has changed in the agent's state and is a valid path.
 
     The state of the agent updates on events like agent restarts, and the log path may change. If there is
     a change, we need to verify that the new path is valid so that we can safely follow the new log file.
@@ -194,7 +194,7 @@ def status():
 
 
 def logs(mode, num_lines, follow=False):
-    """Provides logging information of the agent.
+    """Provide logging information of the agent.
 
     Parameters
     ----------


### PR DESCRIPTION
This commit allows the logging utility to automatically track agent restarts and new logs. This can be helpful during debugging and omits the need to restart logging process.

Contains following changes:
1. The logging path is created directly upon agent starts and doesn't rely on the file logger to later create the path. This allows the logging utility to access the log file immediately without having to wait for some logging action to create the file.
2. In the follow mode, utility now tracks changes in log path of the agent's state and starts following new file.

The changes were tested, and the documentation has also been updated.