### PR TITLE
Require activities for Campaign class

### DIFF
--- a/examples/imagemagick_files.py
+++ b/examples/imagemagick_files.py
@@ -13,7 +13,7 @@ def main():
     Run a shell activity campaign to generate an animated GIF.
     """
 
-    # Setup and configure logger
+    # Setup and configure a logger
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
@@ -25,8 +25,7 @@ def main():
 
     logger.addHandler(ch)
 
-    # Create the campaign
-    campaign = Campaign("My ImageMagick Campaign", logger=logger)
+    # Create a shell activity
     curr_dir = Path.cwd()
 
     activity = ShellActivity(
@@ -47,6 +46,8 @@ def main():
         logger=logger,
     )
 
+    # Create the campaign
+    campaign = Campaign("My ImageMagick Campaign", activities=[activity], logger=logger)
     campaign.add_activity(activity)
 
     # Run the campaign to execute the shell activity

--- a/src/zambeze/campaign/campaign.py
+++ b/src/zambeze/campaign/campaign.py
@@ -20,7 +20,7 @@ class Campaign:
     def __init__(
         self,
         name: str,
-        activities: Optional[list[Activity]] = None,
+        activities: list[Activity],
         logger: Optional[logging.Logger] = None,
         force_login: bool = False,
     ) -> None:
@@ -30,10 +30,10 @@ class Campaign:
         ----------
         name : str
             The name of the campaign.
-        activities : str, optional
+        activities : list
             List of science activities for processing by Zambeze.
         logger : logging.Logger, optional
-            Logger object to flush stderr and stdout
+            Logger object to flush stderr and stdout.
         force_login : bool
             Boolean whether to force a Globus Auth flow.
         """
@@ -41,7 +41,7 @@ class Campaign:
         self.name = name
         self.campaign_id = str(uuid.uuid4())
         self.needs_globus_login = False
-        self.activities = activities if activities is not None else []
+        self.activities = activities
 
         self.force_login = force_login
         self.result_val = "The total wordcount from these books: gatsby, oz is 93944"

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -35,7 +35,7 @@ def test_campaign():
 
     assert activity.campaign_id is None
 
-    campaign = Campaign("My test", logger=logger)
+    campaign = Campaign("My test", activities=[activity], logger=logger)
 
     # Check that the campaign id is correctly added to teh activity
     campaign.add_activity(activity)

--- a/tests/test_message_flow.py
+++ b/tests/test_message_flow.py
@@ -14,9 +14,6 @@ def test_message_creation_from_campaign():  # noqa: C901
     origin_agent_id = "origin_agent_id_1"
     # running_agents = ["running_agent_1", "running_agent_2"]
 
-    # Create a campaign and add
-    campaign = Campaign("My ImageMagick Campaign")
-
     # define an activity
     curr_dir = "foobar"
     activity = ShellActivity(
@@ -60,7 +57,7 @@ def test_message_creation_from_campaign():  # noqa: C901
     """
     *** PHASE 2: Creating DAG from activity works properly ***
     """
-    campaign.add_activity(activity)
+    campaign = Campaign("My ImageMagick Campaign", activities=[activity])
     internal_dag = campaign._pack_dag_for_dispatch()
     assert isinstance(internal_dag, DAG)
 


### PR DESCRIPTION
This requires the `Campaign` class to be initialized with a list of activities. Tests and the ImageMagik example have been updated accordingly. Closes issue #175 .