### PR TITLE
Use a single string for command arguments

### DIFF
--- a/examples/imagemagick_files.py
+++ b/examples/imagemagick_files.py
@@ -35,14 +35,7 @@ def main():
             for i in range(1, 11)
         ],
         command="convert",
-        arguments=[
-            "-delay",
-            "20",
-            "-loop",
-            "0",
-            f"{curr_dir}/../tests/campaigns/imagesequence/*.jpg",
-            "a.gif",
-        ],
+        arguments=f"-delay 20 -loop 0 {curr_dir}/../tests/campaigns/imagesequence/*.jpg a.gif",
         logger=logger,
     )
 

--- a/src/zambeze/campaign/activities/shell.py
+++ b/src/zambeze/campaign/activities/shell.py
@@ -18,22 +18,21 @@ from zambeze.orchestration.zambeze_types import MessageType, ActivityType
 
 
 class ShellActivity(Activity):
-    """A Unix Shell script/command activity.
+    """A unix shell script/command activity.
 
-    :param name: Campaign activity name.
-    :type name: str
-
-    :param files: List of file URIs.
-    :type files: Optional[list[str]]
-
-    :param command: Action's command.
-    :type command: Optional[str]
-
-    :param arguments: List of arguments.
-    :type arguments: Optional[list[str]]
-
-    :param logger: The logger where to log information/warning or errors.
-    :type logger: Optional[logging.Logger]
+    Attributes
+    ----------
+    name : str
+        Name of the campaign activity.
+    files : list
+        List of the file URIs.
+    command : str
+        The action command for this activity.
+    arguments : str
+        The arguments for the command as one string. Each argument in the
+        string must be separated by a space.
+    logger : Logger
+        The logger where to log information/warning or errors.
     """
 
     def __init__(
@@ -41,7 +40,7 @@ class ShellActivity(Activity):
         name: str,
         files: list[str],
         command: str,
-        arguments: list[str],
+        arguments: str,
         logger: logging.Logger = None,
         campaign_id: Optional[str] = None,
         origin_agent_id: Optional[str] = None,
@@ -53,7 +52,7 @@ class ShellActivity(Activity):
             name,
             files,
             command,
-            arguments,
+            arguments.split(" "),
             logger,
             campaign_id,
             origin_agent_id,

--- a/tests/test_activity_shell.py
+++ b/tests/test_activity_shell.py
@@ -21,14 +21,7 @@ def test_shell_activity_generate_message():
             for i in range(1, 11)
         ],
         command="convert",
-        arguments=[
-            "-delay",
-            "20",
-            "-loop",
-            "0",
-            f"{curr_dir}/../tests/campaigns/imagesequence/*.jpg",
-            "a.gif",
-        ],
+        arguments=f"-delay 20 -loop 0 {curr_dir}/../tests/campaigns/imagesequence/*.jpg a.gif",
         logger=logger,
         # Uncomment if running on M1 Mac.
         env_vars={"PATH": "$PATH:/opt/homebrew/bin"},
@@ -68,14 +61,7 @@ def test_shell_activity_attributes():
             for i in range(1, 11)
         ],
         command="convert",
-        arguments=[
-            "-delay",
-            "20",
-            "-loop",
-            "0",
-            f"{curr_dir}/../tests/campaigns/imagesequence/*.jpg",
-            "a.gif",
-        ],
+        arguments=f"-delay 20 -loop 0 {curr_dir}/../tests/campaigns/imagesequence/*.jpg a.gif",
         logger=logger,
         # Uncomment if running on M1 Mac.
         env_vars={"PATH": "$PATH:/opt/homebrew/bin"},

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -20,14 +20,7 @@ def test_campaign():
             for i in range(1, 11)
         ],
         command="convert",
-        arguments=[
-            "-delay",
-            "20",
-            "-loop",
-            "0",
-            f"{curr_dir}/../tests/campaigns/imagesequence/*.jpg",
-            "a.gif",
-        ],
+        arguments=f"-delay 20 -loop 0 {curr_dir}/../tests/campaigns/imagesequence/*.jpg a.gif",
         logger=logger,
         # Uncomment if running on M1 Mac.
         env_vars={"PATH": "$PATH:/opt/homebrew/bin"},

--- a/tests/test_hierarchical_structure.py
+++ b/tests/test_hierarchical_structure.py
@@ -6,7 +6,7 @@ from zambeze.campaign.activities.abstract_activity import Activity
 @pytest.mark.unit
 def test_shell_activity_is_activity():
     activity = ShellActivity(
-        name="Simple activity ", files=[], command="echo", arguments=["hello"]
+        name="Simple activity ", files=[], command="echo", arguments="hello"
     )
 
     assert isinstance(activity, ShellActivity)

--- a/tests/test_message_flow.py
+++ b/tests/test_message_flow.py
@@ -23,14 +23,7 @@ def test_message_creation_from_campaign():  # noqa: C901
             for i in range(1, 11)
         ],
         command="convert",
-        arguments=[
-            "-delay",
-            "20",
-            "-loop",
-            "0",
-            f"{curr_dir}/../tests/campaigns/imagesequence/*.jpg",
-            "a.gif",
-        ],
+        arguments=f"-delay 20 -loop 0 {curr_dir}/../tests/campaigns/imagesequence/*.jpg a.gif",
         # Uncomment if running on M1 Mac.
         env_vars={"PATH": "${PATH}:/opt/homebrew/bin"},
     )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -43,7 +43,7 @@ def test_shell_plugin_check():
     plugins.configure({"shell": {}})
 
     activity = ShellActivity(
-        name="Simple echo", files=[], command="echo", arguments=["hello-zambeze"]
+        name="Simple echo", files=[], command="echo", arguments="hello-zambeze"
     )
 
     activity.message_id = str(uuid.uuid4())
@@ -77,7 +77,7 @@ def test_shell_plugin_run():
     # )
 
     activity = ShellActivity(
-        name="Simple echo", files=[], command="touch", arguments=[file_path]
+        name="Simple echo", files=[], command="touch", arguments=file_path
     )
 
     activity.message_id = str(uuid.uuid4())


### PR DESCRIPTION
This enables a user to provide a single string for the command arguments instead of a list of strings. The tests were updated to account for this change. Resolves #174.