### PR TITLE
Add connection recovery to rmq on publish

### DIFF
--- a/src/zambeze/orchestration/queue/queue_rmq.py
+++ b/src/zambeze/orchestration/queue/queue_rmq.py
@@ -1,10 +1,10 @@
+import dill
 import logging
+import pika
 
 from .abstract_queue import AbstractQueue
 from .queue_exceptions import QueueTimeoutException
 from ..zambeze_types import ChannelType, QueueType
-import dill
-import pika
 
 
 class QueueRMQ(AbstractQueue):

--- a/src/zambeze/orchestration/queue/queue_rmq.py
+++ b/src/zambeze/orchestration/queue/queue_rmq.py
@@ -217,3 +217,4 @@ class QueueRMQ(AbstractQueue):
         self._rmq = None
         self._rmq_channel = None
         self._sub = {}
+        self.__disconnected()

--- a/src/zambeze/orchestration/queue/queue_rmq.py
+++ b/src/zambeze/orchestration/queue/queue_rmq.py
@@ -156,22 +156,18 @@ class QueueRMQ(AbstractQueue):
     def next_msg(self, channel: ChannelType):
         if not self._sub:
             raise Exception(
-                "Cannot get next message client is not subscribed \
-                    to any RabbitMQ topic"
+                "Cannot get next message client is not subscribed to any RabbitMQ topic"
             )
         if channel not in self._sub:
             raise Exception(
-                f"Cannot get next message client is not subscribed \
-                        to any RabbitMQ topic: {channel.value}"
+                f"Cannot get next message client is not subscribed to any RabbitMQ topic: {channel.value}"
             )
 
         try:
             msg = self._sub[channel].next_msg(timeout=1)
             data = dill.loads(msg.data)
         except Exception as e:
-            error_msg = "next_msg call - checking RabbitMQ"
-            error_msg += f" error: {e}"
-            raise QueueTimeoutException(error_msg)
+            raise QueueTimeoutException(f"[next_msg] Timeout: {e}")
 
         return data
 

--- a/src/zambeze/orchestration/queue/queue_rmq.py
+++ b/src/zambeze/orchestration/queue/queue_rmq.py
@@ -103,17 +103,30 @@ class QueueRMQ(AbstractQueue):
         """Listen for messages on a persistent websocket connection;
         --> do action in callback function on receipt."""
 
-        listen_on_channel = self._rmq_channel
+        try:
+            listen_on_channel = self._rmq_channel
 
-        s = f"[message_handler] Waiting with listener on RabbitMQ channel {channel_to_listen}"
-        self._logger.debug(s)
+            s = f"[message_handler] Waiting with listener on RabbitMQ channel {channel_to_listen}"
+            self._logger.debug(s)
 
-        listen_on_channel.basic_consume(
-            queue=channel_to_listen,
-            on_message_callback=callback_func,
-            auto_ack=should_auto_ack,
-        )
-        listen_on_channel.start_consuming()
+            listen_on_channel.basic_consume(
+                queue=channel_to_listen,
+                on_message_callback=callback_func,
+                auto_ack=should_auto_ack,
+            )
+            listen_on_channel.start_consuming()
+        # Do not recover if connection was closed by broker
+        except pika.exceptions.ConnectionClosedByBroker:
+            raise
+        # Do not recover on channel errors
+        except pika.exceptions.AMQPChannelError:
+            raise
+        # Recover on all other connection errors
+        except pika.exceptions.AMQPConnectionError:
+            self.reconnect()
+            self.listen_and_do_callback(
+                callback_func, channel_to_listen, should_auto_ack
+            )
 
     @property
     def subscriptions(self) -> list[ChannelType]:
@@ -185,10 +198,10 @@ class QueueRMQ(AbstractQueue):
             )
         # Do not recover if connection was closed by broker
         except pika.exceptions.ConnectionClosedByBroker:
-            pass
+            raise
         # Do not recover on channel errors
         except pika.exceptions.AMQPChannelError:
-            pass
+            raise
         # Recover on all other connection errors
         except pika.exceptions.AMQPConnectionError:
             self.reconnect()


### PR DESCRIPTION
**Issue description:**

If campaigns are launched with long intervals between them, the RabbitMQ server closes the connection. This happens because the RabbitMQ server expects regular heartbeats from its connections, but it didn't receive heartbeats within the default timeout. This is the log on the RabbitMQ side:
```
2024-07-07 21:45:42.724472+00:00 [error] <0.2779.0> closing AMQP connection <0.2779.0> (172.17.0.1:44258 -> 172.17.0.2:5672):
2024-07-07 21:45:42.724472+00:00 [error] <0.2779.0> missed heartbeats from client, timeout: 60s
```

Within Zambeze, we are maintaining 4 different connections to the RabbitMQ server which are within `message_handler`. Two of them are consumers (`recv_activity`, `recv_control`) and are able to maintain the heartbeats when they [start_consuming](https://github.com/flourishingtune/Zambeze/blob/main/src/zambeze/orchestration/queue/queue_rmq.py#L110), thus they don't lose the connection. This can be verified by launching `tshark` and monitoring the port `5672`.

With producers (`send_activity_dag`, `send_control`), when we have gaps between launches, the [basic_publish](https://github.com/flourishingtune/Zambeze/blob/main/src/zambeze/orchestration/queue/queue_rmq.py#L176-L178) doesn't run and the RabbitMQ thus doesn't know if the connection is still active and closes the connection after the default timeout. Unlike `start_consuming` on the consumer side, the `basic_publish` on the producer is only responsible for publishing messages to channels and doesn't maintain heartbeats.

**Resolution:**

The issue can be resolved by either maintaining regular heartbeats from the producers, or by implementing connection recovery when the `basic_publish` fails to publish message due to the lost connection. Seems like we can turn off the heartbeats altogether, but it is not recommended for reasons like monitoring, resource management, etc. I discovered that both of the implementations are documented on the `pika` library repository ([maintaining heartbeats](https://github.com/pika/pika/blob/main/examples/long_running_publisher.py) and [recovery](https://github.com/pika/pika/blob/main/examples/blocking_consume_recover_multiple_hosts.py)). I have implemented the second approach of recovery since it doesn't require maintaining heartbeats and is a bit easy on CPU. 

**Tests:**

I tested the recovery approach with varying intervals (10-30 minutes) via a dummy bash script that intermittently launches jobs and made sure the connection lost log was seen in the RabbitMQ logs before launching new campaigns. I verified that the publisher was able to send messages by looking at the corresponding logs. The followed the relay of the new messages from the `message_handler` to the `executor` and verified that they were relaying properly within Zambeze.

Before:
```
2024-07-07 16:37:27,007 - zambeze.cli_agent - ERROR - [mh] UNABLE TO SEND ACTIVITY MESSAGE! CAUGHT: StreamLostError: Transport indicated EOF
```
After:
```
2024-07-07 16:46:25,668 - zambeze.cli_agent - DEBUG - [send_activity] Successfully sent activity!
```
I verified that the RabbitMQ received the new recovery connections:

```
2024-07-07 21:46:25.636570+00:00 [info] <0.2846.0> accepting AMQP connection <0.2846.0> (172.17.0.1:48978 -> 172.17.0.2:5672)
2024-07-07 21:46:25.649824+00:00 [info] <0.2846.0> connection <0.2846.0> (172.17.0.1:48978 -> 172.17.0.2:5672): user 'guest' authenticated and granted access to vhost '/'
2024-07-07 21:46:32.697239+00:00 [info] <0.2859.0> accepting AMQP connection <0.2859.0> (172.17.0.1:54738 -> 172.17.0.2:5672)
2024-07-07 21:46:32.702999+00:00 [info] <0.2859.0> connection <0.2859.0> (172.17.0.1:54738 -> 172.17.0.2:5672): user 'guest' authenticated and granted access to vhost '/'
```

I noticed that the subsequent runs of campaigns (i.e. more than 1) is failing and had issues even without RabbitMQ connection loss. I think it would be good to address those in a different PR.

Please let me know if there are other tests you would like me to look into. Thanks!