### PR TITLE
Clean up ordered word count example

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+# Docker Compose file for running a RabbitMQ broker
+# More info about RabbitMQ at https://www.rabbitmq.com
+
+# Commands for using Docker Compose
+# Create and start containers ............... docker compose up
+# Create and start in detached mode ......... docker compuse up -d
+# Stop active services in terminal .......... press Ctrl+C
+# Stop and remove containers and networks ... docker compose down
+
+services:
+
+  rabbitmq:
+    image: "rabbitmq:3.13-management"
+    container_name: "rabbitmq"
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/examples/ordered_wordcount/gatsby_book.txt
+++ b/examples/ordered_wordcount/gatsby_book.txt
@@ -1,0 +1,6823 @@
+﻿
+    The Project Gutenberg eBook of The Great Gatsby
+    
+This ebook is for the use of anyone anywhere in the United States and 
+most other parts of the world at no cost and with almost no restrictions 
+whatsoever. You may copy it, give it away or re-use it under the terms 
+of the Project Gutenberg License included with this ebook or online 
+at www.gutenberg.org. If you are not located in the United States, 
+you will have to check the laws of the country where you are located 
+before using this eBook.
+
+
+
+    
+        Title: The Great Gatsby
+        
+        Author: F. Scott Fitzgerald
+
+        
+        Release date: January 17, 2021 [eBook #64317]
+        Language: English
+        
+        
+    
+        
+            *** START OF THE PROJECT GUTENBERG EBOOK THE GREAT GATSBY ***
+        
+
+			   The Great Gatsby
+				  by
+			 F. Scott Fitzgerald
+
+
+                           Table of Contents
+
+I
+II
+III
+IV
+V
+VI
+VII
+VIII
+IX
+
+
+                              Once again
+                                  to
+                                 Zelda
+
+  Then wear the gold hat, if that will move her;
+  If you can bounce high, bounce for her too,
+  Till she cry “Lover, gold-hatted, high-bouncing lover,
+  I must have you!”
+
+  Thomas Parke d’Invilliers
+
+
+                                  I
+
+In my younger and more vulnerable years my father gave me some advice
+that I’ve been turning over in my mind ever since.
+
+“Whenever you feel like criticizing anyone,” he told me, “just
+remember that all the people in this world haven’t had the advantages
+that you’ve had.”
+
+He didn’t say any more, but we’ve always been unusually communicative
+in a reserved way, and I understood that he meant a great deal more
+than that. In consequence, I’m inclined to reserve all judgements, a
+habit that has opened up many curious natures to me and also made me
+the victim of not a few veteran bores. The abnormal mind is quick to
+detect and attach itself to this quality when it appears in a normal
+person, and so it came about that in college I was unjustly accused of
+being a politician, because I was privy to the secret griefs of wild,
+unknown men. Most of the confidences were unsought—frequently I have
+feigned sleep, preoccupation, or a hostile levity when I realized by
+some unmistakable sign that an intimate revelation was quivering on
+the horizon; for the intimate revelations of young men, or at least
+the terms in which they express them, are usually plagiaristic and
+marred by obvious suppressions. Reserving judgements is a matter of
+infinite hope. I am still a little afraid of missing something if I
+forget that, as my father snobbishly suggested, and I snobbishly
+repeat, a sense of the fundamental decencies is parcelled out
+unequally at birth.
+
+And, after boasting this way of my tolerance, I come to the admission
+that it has a limit. Conduct may be founded on the hard rock or the
+wet marshes, but after a certain point I don’t care what it’s founded
+on. When I came back from the East last autumn I felt that I wanted
+the world to be in uniform and at a sort of moral attention forever; I
+wanted no more riotous excursions with privileged glimpses into the
+human heart. Only Gatsby, the man who gives his name to this book, was
+exempt from my reaction—Gatsby, who represented everything for which I
+have an unaffected scorn. If personality is an unbroken series of
+successful gestures, then there was something gorgeous about him, some
+heightened sensitivity to the promises of life, as if he were related
+to one of those intricate machines that register earthquakes ten
+thousand miles away. This responsiveness had nothing to do with that
+flabby impressionability which is dignified under the name of the
+“creative temperament”—it was an extraordinary gift for hope, a
+romantic readiness such as I have never found in any other person and
+which it is not likely I shall ever find again. No—Gatsby turned out
+all right at the end; it is what preyed on Gatsby, what foul dust
+floated in the wake of his dreams that temporarily closed out my
+interest in the abortive sorrows and short-winded elations of men.
+
+------------------------------------------------------------------------
+
+My family have been prominent, well-to-do people in this Middle
+Western city for three generations. The Carraways are something of a
+clan, and we have a tradition that we’re descended from the Dukes of
+Buccleuch, but the actual founder of my line was my grandfather’s
+brother, who came here in fifty-one, sent a substitute to the Civil
+War, and started the wholesale hardware business that my father
+carries on today.
+
+I never saw this great-uncle, but I’m supposed to look like him—with
+special reference to the rather hard-boiled painting that hangs in
+father’s office. I graduated from New Haven in 1915, just a quarter of
+a century after my father, and a little later I participated in that
+delayed Teutonic migration known as the Great War. I enjoyed the
+counter-raid so thoroughly that I came back restless. Instead of being
+the warm centre of the world, the Middle West now seemed like the
+ragged edge of the universe—so I decided to go East and learn the bond
+business. Everybody I knew was in the bond business, so I supposed it
+could support one more single man. All my aunts and uncles talked it
+over as if they were choosing a prep school for me, and finally said,
+“Why—ye-es,” with very grave, hesitant faces. Father agreed to finance
+me for a year, and after various delays I came East, permanently, I
+thought, in the spring of twenty-two.
+
+The practical thing was to find rooms in the city, but it was a warm
+season, and I had just left a country of wide lawns and friendly
+trees, so when a young man at the office suggested that we take a
+house together in a commuting town, it sounded like a great idea. He
+found the house, a weather-beaten cardboard bungalow at eighty a
+month, but at the last minute the firm ordered him to Washington, and
+I went out to the country alone. I had a dog—at least I had him for a
+few days until he ran away—and an old Dodge and a Finnish woman, who
+made my bed and cooked breakfast and muttered Finnish wisdom to
+herself over the electric stove.
+
+It was lonely for a day or so until one morning some man, more
+recently arrived than I, stopped me on the road.
+
+“How do you get to West Egg village?” he asked helplessly.
+
+I told him. And as I walked on I was lonely no longer. I was a guide,
+a pathfinder, an original settler. He had casually conferred on me the
+freedom of the neighbourhood.
+
+And so with the sunshine and the great bursts of leaves growing on the
+trees, just as things grow in fast movies, I had that familiar
+conviction that life was beginning over again with the summer.
+
+There was so much to read, for one thing, and so much fine health to
+be pulled down out of the young breath-giving air. I bought a dozen
+volumes on banking and credit and investment securities, and they
+stood on my shelf in red and gold like new money from the mint,
+promising to unfold the shining secrets that only Midas and Morgan and
+Maecenas knew. And I had the high intention of reading many other
+books besides. I was rather literary in college—one year I wrote a
+series of very solemn and obvious editorials for the Yale News—and now
+I was going to bring back all such things into my life and become
+again that most limited of all specialists, the “well-rounded man.”
+This isn’t just an epigram—life is much more successfully looked at
+from a single window, after all.
+
+It was a matter of chance that I should have rented a house in one of
+the strangest communities in North America. It was on that slender
+riotous island which extends itself due east of New York—and where
+there are, among other natural curiosities, two unusual formations of
+land. Twenty miles from the city a pair of enormous eggs, identical in
+contour and separated only by a courtesy bay, jut out into the most
+domesticated body of salt water in the Western hemisphere, the great
+wet barnyard of Long Island Sound. They are not perfect ovals—like the
+egg in the Columbus story, they are both crushed flat at the contact
+end—but their physical resemblance must be a source of perpetual
+wonder to the gulls that fly overhead. To the wingless a more
+interesting phenomenon is their dissimilarity in every particular
+except shape and size.
+
+I lived at West Egg, the—well, the less fashionable of the two, though
+this is a most superficial tag to express the bizarre and not a little
+sinister contrast between them. My house was at the very tip of the
+egg, only fifty yards from the Sound, and squeezed between two huge
+places that rented for twelve or fifteen thousand a season. The one on
+my right was a colossal affair by any standard—it was a factual
+imitation of some Hôtel de Ville in Normandy, with a tower on one
+side, spanking new under a thin beard of raw ivy, and a marble
+swimming pool, and more than forty acres of lawn and garden. It was
+Gatsby’s mansion. Or, rather, as I didn’t know Mr. Gatsby, it was a
+mansion inhabited by a gentleman of that name. My own house was an
+eyesore, but it was a small eyesore, and it had been overlooked, so I
+had a view of the water, a partial view of my neighbour’s lawn, and
+the consoling proximity of millionaires—all for eighty dollars a
+month.
+
+Across the courtesy bay the white palaces of fashionable East Egg
+glittered along the water, and the history of the summer really begins
+on the evening I drove over there to have dinner with the Tom
+Buchanans. Daisy was my second cousin once removed, and I’d known Tom
+in college. And just after the war I spent two days with them in
+Chicago.
+
+Her husband, among various physical accomplishments, had been one of
+the most powerful ends that ever played football at New Haven—a
+national figure in a way, one of those men who reach such an acute
+limited excellence at twenty-one that everything afterward savours of
+anticlimax. His family were enormously wealthy—even in college his
+freedom with money was a matter for reproach—but now he’d left Chicago
+and come East in a fashion that rather took your breath away: for
+instance, he’d brought down a string of polo ponies from Lake
+Forest. It was hard to realize that a man in my own generation was
+wealthy enough to do that.
+
+Why they came East I don’t know. They had spent a year in France for
+no particular reason, and then drifted here and there unrestfully
+wherever people played polo and were rich together. This was a
+permanent move, said Daisy over the telephone, but I didn’t believe
+it—I had no sight into Daisy’s heart, but I felt that Tom would drift
+on forever seeking, a little wistfully, for the dramatic turbulence of
+some irrecoverable football game.
+
+And so it happened that on a warm windy evening I drove over to East
+Egg to see two old friends whom I scarcely knew at all. Their house
+was even more elaborate than I expected, a cheerful red-and-white
+Georgian Colonial mansion, overlooking the bay. The lawn started at
+the beach and ran towards the front door for a quarter of a mile,
+jumping over sundials and brick walks and burning gardens—finally when
+it reached the house drifting up the side in bright vines as though
+from the momentum of its run. The front was broken by a line of French
+windows, glowing now with reflected gold and wide open to the warm
+windy afternoon, and Tom Buchanan in riding clothes was standing with
+his legs apart on the front porch.
+
+He had changed since his New Haven years. Now he was a sturdy
+straw-haired man of thirty, with a rather hard mouth and a
+supercilious manner. Two shining arrogant eyes had established
+dominance over his face and gave him the appearance of always leaning
+aggressively forward. Not even the effeminate swank of his riding
+clothes could hide the enormous power of that body—he seemed to fill
+those glistening boots until he strained the top lacing, and you could
+see a great pack of muscle shifting when his shoulder moved under his
+thin coat. It was a body capable of enormous leverage—a cruel body.
+
+His speaking voice, a gruff husky tenor, added to the impression of
+fractiousness he conveyed. There was a touch of paternal contempt in
+it, even toward people he liked—and there were men at New Haven who
+had hated his guts.
+
+“Now, don’t think my opinion on these matters is final,” he seemed to
+say, “just because I’m stronger and more of a man than you are.” We
+were in the same senior society, and while we were never intimate I
+always had the impression that he approved of me and wanted me to like
+him with some harsh, defiant wistfulness of his own.
+
+We talked for a few minutes on the sunny porch.
+
+“I’ve got a nice place here,” he said, his eyes flashing about
+restlessly.
+
+Turning me around by one arm, he moved a broad flat hand along the
+front vista, including in its sweep a sunken Italian garden, a half
+acre of deep, pungent roses, and a snub-nosed motorboat that bumped
+the tide offshore.
+
+“It belonged to Demaine, the oil man.” He turned me around again,
+politely and abruptly. “We’ll go inside.”
+
+We walked through a high hallway into a bright rosy-coloured space,
+fragilely bound into the house by French windows at either end. The
+windows were ajar and gleaming white against the fresh grass outside
+that seemed to grow a little way into the house. A breeze blew through
+the room, blew curtains in at one end and out the other like pale
+flags, twisting them up toward the frosted wedding-cake of the
+ceiling, and then rippled over the wine-coloured rug, making a shadow
+on it as wind does on the sea.
+
+The only completely stationary object in the room was an enormous
+couch on which two young women were buoyed up as though upon an
+anchored balloon. They were both in white, and their dresses were
+rippling and fluttering as if they had just been blown back in after a
+short flight around the house. I must have stood for a few moments
+listening to the whip and snap of the curtains and the groan of a
+picture on the wall. Then there was a boom as Tom Buchanan shut the
+rear windows and the caught wind died out about the room, and the
+curtains and the rugs and the two young women ballooned slowly to the
+floor.
+
+The younger of the two was a stranger to me. She was extended full
+length at her end of the divan, completely motionless, and with her
+chin raised a little, as if she were balancing something on it which
+was quite likely to fall. If she saw me out of the corner of her eyes
+she gave no hint of it—indeed, I was almost surprised into murmuring
+an apology for having disturbed her by coming in.
+
+The other girl, Daisy, made an attempt to rise—she leaned slightly
+forward with a conscientious expression—then she laughed, an absurd,
+charming little laugh, and I laughed too and came forward into the
+room.
+
+“I’m p-paralysed with happiness.”
+
+She laughed again, as if she said something very witty, and held my
+hand for a moment, looking up into my face, promising that there was
+no one in the world she so much wanted to see. That was a way she
+had. She hinted in a murmur that the surname of the balancing girl was
+Baker. (I’ve heard it said that Daisy’s murmur was only to make people
+lean toward her; an irrelevant criticism that made it no less
+charming.)
+
+At any rate, Miss Baker’s lips fluttered, she nodded at me almost
+imperceptibly, and then quickly tipped her head back again—the object
+she was balancing had obviously tottered a little and given her
+something of a fright. Again a sort of apology arose to my lips.
+Almost any exhibition of complete self-sufficiency draws a stunned
+tribute from me.
+
+I looked back at my cousin, who began to ask me questions in her low,
+thrilling voice. It was the kind of voice that the ear follows up and
+down, as if each speech is an arrangement of notes that will never be
+played again. Her face was sad and lovely with bright things in it,
+bright eyes and a bright passionate mouth, but there was an excitement
+in her voice that men who had cared for her found difficult to forget:
+a singing compulsion, a whispered “Listen,” a promise that she had
+done gay, exciting things just a while since and that there were gay,
+exciting things hovering in the next hour.
+
+I told her how I had stopped off in Chicago for a day on my way East,
+and how a dozen people had sent their love through me.
+
+“Do they miss me?” she cried ecstatically.
+
+“The whole town is desolate. All the cars have the left rear wheel
+painted black as a mourning wreath, and there’s a persistent wail all
+night along the north shore.”
+
+“How gorgeous! Let’s go back, Tom. Tomorrow!” Then she added
+irrelevantly: “You ought to see the baby.”
+
+“I’d like to.”
+
+“She’s asleep. She’s three years old. Haven’t you ever seen her?”
+
+“Never.”
+
+“Well, you ought to see her. She’s—”
+
+Tom Buchanan, who had been hovering restlessly about the room, stopped
+and rested his hand on my shoulder.
+
+“What you doing, Nick?”
+
+“I’m a bond man.”
+
+“Who with?”
+
+I told him.
+
+“Never heard of them,” he remarked decisively.
+
+This annoyed me.
+
+“You will,” I answered shortly. “You will if you stay in the East.”
+
+“Oh, I’ll stay in the East, don’t you worry,” he said, glancing at
+Daisy and then back at me, as if he were alert for something
+more. “I’d be a God damned fool to live anywhere else.”
+
+At this point Miss Baker said: “Absolutely!” with such suddenness that
+I started—it was the first word she had uttered since I came into the
+room. Evidently it surprised her as much as it did me, for she yawned
+and with a series of rapid, deft movements stood up into the room.
+
+“I’m stiff,” she complained, “I’ve been lying on that sofa for as long
+as I can remember.”
+
+“Don’t look at me,” Daisy retorted, “I’ve been trying to get you to
+New York all afternoon.”
+
+“No, thanks,” said Miss Baker to the four cocktails just in from the
+pantry. “I’m absolutely in training.”
+
+Her host looked at her incredulously.
+
+“You are!” He took down his drink as if it were a drop in the bottom
+of a glass. “How you ever get anything done is beyond me.”
+
+I looked at Miss Baker, wondering what it was she “got done.” I
+enjoyed looking at her. She was a slender, small-breasted girl, with
+an erect carriage, which she accentuated by throwing her body backward
+at the shoulders like a young cadet. Her grey sun-strained eyes looked
+back at me with polite reciprocal curiosity out of a wan, charming,
+discontented face. It occurred to me now that I had seen her, or a
+picture of her, somewhere before.
+
+“You live in West Egg,” she remarked contemptuously. “I know somebody
+there.”
+
+“I don’t know a single—”
+
+“You must know Gatsby.”
+
+“Gatsby?” demanded Daisy. “What Gatsby?”
+
+Before I could reply that he was my neighbour dinner was announced;
+wedging his tense arm imperatively under mine, Tom Buchanan compelled
+me from the room as though he were moving a checker to another square.
+
+Slenderly, languidly, their hands set lightly on their hips, the two
+young women preceded us out on to a rosy-coloured porch, open toward
+the sunset, where four candles flickered on the table in the
+diminished wind.
+
+“Why candles?” objected Daisy, frowning. She snapped them out with her
+fingers. “In two weeks it’ll be the longest day in the year.” She
+looked at us all radiantly. “Do you always watch for the longest day
+of the year and then miss it? I always watch for the longest day in
+the year and then miss it.”
+
+“We ought to plan something,” yawned Miss Baker, sitting down at the
+table as if she were getting into bed.
+
+“All right,” said Daisy. “What’ll we plan?” She turned to me
+helplessly: “What do people plan?”
+
+Before I could answer her eyes fastened with an awed expression on her
+little finger.
+
+“Look!” she complained; “I hurt it.”
+
+We all looked—the knuckle was black and blue.
+
+“You did it, Tom,” she said accusingly. “I know you didn’t mean to,
+but you did do it. That’s what I get for marrying a brute of a man, a
+great, big, hulking physical specimen of a—”
+
+“I hate that word ‘hulking,’ ” objected Tom crossly, “even in
+kidding.”
+
+“Hulking,” insisted Daisy.
+
+Sometimes she and Miss Baker talked at once, unobtrusively and with a
+bantering inconsequence that was never quite chatter, that was as cool
+as their white dresses and their impersonal eyes in the absence of all
+desire. They were here, and they accepted Tom and me, making only a
+polite pleasant effort to entertain or to be entertained. They knew
+that presently dinner would be over and a little later the evening too
+would be over and casually put away. It was sharply different from the
+West, where an evening was hurried from phase to phase towards its
+close, in a continually disappointed anticipation or else in sheer
+nervous dread of the moment itself.
+
+“You make me feel uncivilized, Daisy,” I confessed on my second glass
+of corky but rather impressive claret. “Can’t you talk about crops or
+something?”
+
+I meant nothing in particular by this remark, but it was taken up in
+an unexpected way.
+
+“Civilization’s going to pieces,” broke out Tom violently. “I’ve
+gotten to be a terrible pessimist about things. Have you read The Rise
+of the Coloured Empires by this man Goddard?”
+
+“Why, no,” I answered, rather surprised by his tone.
+
+“Well, it’s a fine book, and everybody ought to read it. The idea is
+if we don’t look out the white race will be—will be utterly
+submerged. It’s all scientific stuff; it’s been proved.”
+
+“Tom’s getting very profound,” said Daisy, with an expression of
+unthoughtful sadness. “He reads deep books with long words in
+them. What was that word we—”
+
+“Well, these books are all scientific,” insisted Tom, glancing at her
+impatiently. “This fellow has worked out the whole thing. It’s up to
+us, who are the dominant race, to watch out or these other races will
+have control of things.”
+
+“We’ve got to beat them down,” whispered Daisy, winking ferociously
+toward the fervent sun.
+
+“You ought to live in California—” began Miss Baker, but Tom
+interrupted her by shifting heavily in his chair.
+
+“This idea is that we’re Nordics. I am, and you are, and you are,
+and—” After an infinitesimal hesitation he included Daisy with a
+slight nod, and she winked at me again. “—And we’ve produced all the
+things that go to make civilization—oh, science and art, and all
+that. Do you see?”
+
+There was something pathetic in his concentration, as if his
+complacency, more acute than of old, was not enough to him any more.
+When, almost immediately, the telephone rang inside and the butler
+left the porch Daisy seized upon the momentary interruption and leaned
+towards me.
+
+“I’ll tell you a family secret,” she whispered enthusiastically.
+“It’s about the butler’s nose. Do you want to hear about the butler’s
+nose?”
+
+“That’s why I came over tonight.”
+
+“Well, he wasn’t always a butler; he used to be the silver polisher
+for some people in New York that had a silver service for two hundred
+people. He had to polish it from morning till night, until finally it
+began to affect his nose—”
+
+“Things went from bad to worse,” suggested Miss Baker.
+
+“Yes. Things went from bad to worse, until finally he had to give up
+his position.”
+
+For a moment the last sunshine fell with romantic affection upon her
+glowing face; her voice compelled me forward breathlessly as I
+listened—then the glow faded, each light deserting her with lingering
+regret, like children leaving a pleasant street at dusk.
+
+The butler came back and murmured something close to Tom’s ear,
+whereupon Tom frowned, pushed back his chair, and without a word went
+inside. As if his absence quickened something within her, Daisy leaned
+forward again, her voice glowing and singing.
+
+“I love to see you at my table, Nick. You remind me of a—of a rose, an
+absolute rose. Doesn’t he?” She turned to Miss Baker for confirmation:
+“An absolute rose?”
+
+This was untrue. I am not even faintly like a rose. She was only
+extemporizing, but a stirring warmth flowed from her, as if her heart
+was trying to come out to you concealed in one of those breathless,
+thrilling words. Then suddenly she threw her napkin on the table and
+excused herself and went into the house.
+
+Miss Baker and I exchanged a short glance consciously devoid of
+meaning. I was about to speak when she sat up alertly and said “Sh!”
+in a warning voice. A subdued impassioned murmur was audible in the
+room beyond, and Miss Baker leaned forward unashamed, trying to
+hear. The murmur trembled on the verge of coherence, sank down,
+mounted excitedly, and then ceased altogether.
+
+“This Mr. Gatsby you spoke of is my neighbour—” I began.
+
+“Don’t talk. I want to hear what happens.”
+
+“Is something happening?” I inquired innocently.
+
+“You mean to say you don’t know?” said Miss Baker, honestly surprised.
+“I thought everybody knew.”
+
+“I don’t.”
+
+“Why—” she said hesitantly. “Tom’s got some woman in New York.”
+
+“Got some woman?” I repeated blankly.
+
+Miss Baker nodded.
+
+“She might have the decency not to telephone him at dinner time.
+Don’t you think?”
+
+Almost before I had grasped her meaning there was the flutter of a
+dress and the crunch of leather boots, and Tom and Daisy were back at
+the table.
+
+“It couldn’t be helped!” cried Daisy with tense gaiety.
+
+She sat down, glanced searchingly at Miss Baker and then at me, and
+continued: “I looked outdoors for a minute, and it’s very romantic
+outdoors. There’s a bird on the lawn that I think must be a
+nightingale come over on the Cunard or White Star Line. He’s singing
+away—” Her voice sang: “It’s romantic, isn’t it, Tom?”
+
+“Very romantic,” he said, and then miserably to me: “If it’s light
+enough after dinner, I want to take you down to the stables.”
+
+The telephone rang inside, startlingly, and as Daisy shook her head
+decisively at Tom the subject of the stables, in fact all subjects,
+vanished into air. Among the broken fragments of the last five minutes
+at table I remember the candles being lit again, pointlessly, and I
+was conscious of wanting to look squarely at everyone, and yet to
+avoid all eyes. I couldn’t guess what Daisy and Tom were thinking, but
+I doubt if even Miss Baker, who seemed to have mastered a certain
+hardy scepticism, was able utterly to put this fifth guest’s shrill
+metallic urgency out of mind. To a certain temperament the situation
+might have seemed intriguing—my own instinct was to telephone
+immediately for the police.
+
+The horses, needless to say, were not mentioned again. Tom and Miss
+Baker, with several feet of twilight between them, strolled back into
+the library, as if to a vigil beside a perfectly tangible body, while,
+trying to look pleasantly interested and a little deaf, I followed
+Daisy around a chain of connecting verandas to the porch in front. In
+its deep gloom we sat down side by side on a wicker settee.
+
+Daisy took her face in her hands as if feeling its lovely shape, and
+her eyes moved gradually out into the velvet dusk. I saw that
+turbulent emotions possessed her, so I asked what I thought would be
+some sedative questions about her little girl.
+
+“We don’t know each other very well, Nick,” she said suddenly. “Even
+if we are cousins. You didn’t come to my wedding.”
+
+“I wasn’t back from the war.”
+
+“That’s true.” She hesitated. “Well, I’ve had a very bad time, Nick,
+and I’m pretty cynical about everything.”
+
+Evidently she had reason to be. I waited but she didn’t say any more,
+and after a moment I returned rather feebly to the subject of her
+daughter.
+
+“I suppose she talks, and—eats, and everything.”
+
+“Oh, yes.” She looked at me absently. “Listen, Nick; let me tell you
+what I said when she was born. Would you like to hear?”
+
+“Very much.”
+
+“It’ll show you how I’ve gotten to feel about—things. Well, she was
+less than an hour old and Tom was God knows where. I woke up out of
+the ether with an utterly abandoned feeling, and asked the nurse right
+away if it was a boy or a girl. She told me it was a girl, and so I
+turned my head away and wept. ‘All right,’ I said, ‘I’m glad it’s a
+girl. And I hope she’ll be a fool—that’s the best thing a girl can be
+in this world, a beautiful little fool.’
+
+“You see I think everything’s terrible anyhow,” she went on in a
+convinced way. “Everybody thinks so—the most advanced people. And I
+know. I’ve been everywhere and seen everything and done everything.”
+Her eyes flashed around her in a defiant way, rather like Tom’s, and
+she laughed with thrilling scorn. “Sophisticated—God, I’m
+sophisticated!”
+
+The instant her voice broke off, ceasing to compel my attention, my
+belief, I felt the basic insincerity of what she had said. It made me
+uneasy, as though the whole evening had been a trick of some sort to
+exact a contributory emotion from me. I waited, and sure enough, in a
+moment she looked at me with an absolute smirk on her lovely face, as
+if she had asserted her membership in a rather distinguished secret
+society to which she and Tom belonged.
+
+------------------------------------------------------------------------
+
+Inside, the crimson room bloomed with light. Tom and Miss Baker sat at
+either end of the long couch and she read aloud to him from the
+Saturday Evening Post—the words, murmurous and uninflected, running
+together in a soothing tune. The lamplight, bright on his boots and
+dull on the autumn-leaf yellow of her hair, glinted along the paper as
+she turned a page with a flutter of slender muscles in her arms.
+
+When we came in she held us silent for a moment with a lifted hand.
+
+“To be continued,” she said, tossing the magazine on the table, “in
+our very next issue.”
+
+Her body asserted itself with a restless movement of her knee, and she
+stood up.
+
+“Ten o’clock,” she remarked, apparently finding the time on the
+ceiling. “Time for this good girl to go to bed.”
+
+“Jordan’s going to play in the tournament tomorrow,” explained Daisy,
+“over at Westchester.”
+
+“Oh—you’re Jordan Baker.”
+
+I knew now why her face was familiar—its pleasing contemptuous
+expression had looked out at me from many rotogravure pictures of the
+sporting life at Asheville and Hot Springs and Palm Beach. I had heard
+some story of her too, a critical, unpleasant story, but what it was I
+had forgotten long ago.
+
+“Good night,” she said softly. “Wake me at eight, won’t you.”
+
+“If you’ll get up.”
+
+“I will. Good night, Mr. Carraway. See you anon.”
+
+“Of course you will,” confirmed Daisy. “In fact I think I’ll arrange a
+marriage. Come over often, Nick, and I’ll sort of—oh—fling you
+together. You know—lock you up accidentally in linen closets and push
+you out to sea in a boat, and all that sort of thing—”
+
+“Good night,” called Miss Baker from the stairs. “I haven’t heard a
+word.”
+
+“She’s a nice girl,” said Tom after a moment. “They oughtn’t to let
+her run around the country this way.”
+
+“Who oughtn’t to?” inquired Daisy coldly.
+
+“Her family.”
+
+“Her family is one aunt about a thousand years old. Besides, Nick’s
+going to look after her, aren’t you, Nick? She’s going to spend lots
+of weekends out here this summer. I think the home influence will be
+very good for her.”
+
+Daisy and Tom looked at each other for a moment in silence.
+
+“Is she from New York?” I asked quickly.
+
+“From Louisville. Our white girlhood was passed together there. Our
+beautiful white—”
+
+“Did you give Nick a little heart to heart talk on the veranda?”
+demanded Tom suddenly.
+
+“Did I?” She looked at me. “I can’t seem to remember, but I think we
+talked about the Nordic race. Yes, I’m sure we did. It sort of crept
+up on us and first thing you know—”
+
+“Don’t believe everything you hear, Nick,” he advised me.
+
+I said lightly that I had heard nothing at all, and a few minutes
+later I got up to go home. They came to the door with me and stood
+side by side in a cheerful square of light. As I started my motor
+Daisy peremptorily called: “Wait!”
+
+“I forgot to ask you something, and it’s important. We heard you were
+engaged to a girl out West.”
+
+“That’s right,” corroborated Tom kindly. “We heard that you were
+engaged.”
+
+“It’s a libel. I’m too poor.”
+
+“But we heard it,” insisted Daisy, surprising me by opening up again
+in a flower-like way. “We heard it from three people, so it must be
+true.”
+
+Of course I knew what they were referring to, but I wasn’t even
+vaguely engaged. The fact that gossip had published the banns was one
+of the reasons I had come East. You can’t stop going with an old
+friend on account of rumours, and on the other hand I had no intention
+of being rumoured into marriage.
+
+Their interest rather touched me and made them less remotely
+rich—nevertheless, I was confused and a little disgusted as I drove
+away. It seemed to me that the thing for Daisy to do was to rush out
+of the house, child in arms—but apparently there were no such
+intentions in her head. As for Tom, the fact that he “had some woman
+in New York” was really less surprising than that he had been
+depressed by a book. Something was making him nibble at the edge of
+stale ideas as if his sturdy physical egotism no longer nourished his
+peremptory heart.
+
+Already it was deep summer on roadhouse roofs and in front of wayside
+garages, where new red petrol-pumps sat out in pools of light, and
+when I reached my estate at West Egg I ran the car under its shed and
+sat for a while on an abandoned grass roller in the yard. The wind had
+blown off, leaving a loud, bright night, with wings beating in the
+trees and a persistent organ sound as the full bellows of the earth
+blew the frogs full of life. The silhouette of a moving cat wavered
+across the moonlight, and, turning my head to watch it, I saw that I
+was not alone—fifty feet away a figure had emerged from the shadow of
+my neighbour’s mansion and was standing with his hands in his pockets
+regarding the silver pepper of the stars. Something in his leisurely
+movements and the secure position of his feet upon the lawn suggested
+that it was Mr. Gatsby himself, come out to determine what share was
+his of our local heavens.
+
+I decided to call to him. Miss Baker had mentioned him at dinner, and
+that would do for an introduction. But I didn’t call to him, for he
+gave a sudden intimation that he was content to be alone—he stretched
+out his arms toward the dark water in a curious way, and, far as I was
+from him, I could have sworn he was trembling. Involuntarily I glanced
+seaward—and distinguished nothing except a single green light, minute
+and far away, that might have been the end of a dock. When I looked
+once more for Gatsby he had vanished, and I was alone again in the
+unquiet darkness.
+
+
+                                  II
+
+About halfway between West Egg and New York the motor road hastily
+joins the railroad and runs beside it for a quarter of a mile, so as
+to shrink away from a certain desolate area of land. This is a valley
+of ashes—a fantastic farm where ashes grow like wheat into ridges and
+hills and grotesque gardens; where ashes take the forms of houses and
+chimneys and rising smoke and, finally, with a transcendent effort, of
+ash-grey men, who move dimly and already crumbling through the powdery
+air. Occasionally a line of grey cars crawls along an invisible track,
+gives out a ghastly creak, and comes to rest, and immediately the
+ash-grey men swarm up with leaden spades and stir up an impenetrable
+cloud, which screens their obscure operations from your sight.
+
+But above the grey land and the spasms of bleak dust which drift
+endlessly over it, you perceive, after a moment, the eyes of Doctor T.
+J. Eckleburg. The eyes of Doctor T. J. Eckleburg are blue and
+gigantic—their retinas are one yard high. They look out of no face,
+but, instead, from a pair of enormous yellow spectacles which pass
+over a nonexistent nose. Evidently some wild wag of an oculist set
+them there to fatten his practice in the borough of Queens, and then
+sank down himself into eternal blindness, or forgot them and moved
+away. But his eyes, dimmed a little by many paintless days, under sun
+and rain, brood on over the solemn dumping ground.
+
+The valley of ashes is bounded on one side by a small foul river, and,
+when the drawbridge is up to let barges through, the passengers on
+waiting trains can stare at the dismal scene for as long as half an
+hour. There is always a halt there of at least a minute, and it was
+because of this that I first met Tom Buchanan’s mistress.
+
+The fact that he had one was insisted upon wherever he was known. His
+acquaintances resented the fact that he turned up in popular cafés
+with her and, leaving her at a table, sauntered about, chatting with
+whomsoever he knew. Though I was curious to see her, I had no desire
+to meet her—but I did. I went up to New York with Tom on the train one
+afternoon, and when we stopped by the ash-heaps he jumped to his feet
+and, taking hold of my elbow, literally forced me from the car.
+
+“We’re getting off,” he insisted. “I want you to meet my girl.”
+
+I think he’d tanked up a good deal at luncheon, and his determination
+to have my company bordered on violence. The supercilious assumption
+was that on Sunday afternoon I had nothing better to do.
+
+I followed him over a low whitewashed railroad fence, and we walked
+back a hundred yards along the road under Doctor Eckleburg’s
+persistent stare. The only building in sight was a small block of
+yellow brick sitting on the edge of the waste land, a sort of compact
+Main Street ministering to it, and contiguous to absolutely nothing.
+One of the three shops it contained was for rent and another was an
+all-night restaurant, approached by a trail of ashes; the third was a
+garage—Repairs. George B. Wilson. Cars bought and sold.—and I followed
+Tom inside.
+
+The interior was unprosperous and bare; the only car visible was the
+dust-covered wreck of a Ford which crouched in a dim corner. It had
+occurred to me that this shadow of a garage must be a blind, and that
+sumptuous and romantic apartments were concealed overhead, when the
+proprietor himself appeared in the door of an office, wiping his hands
+on a piece of waste. He was a blond, spiritless man, anaemic, and
+faintly handsome. When he saw us a damp gleam of hope sprang into his
+light blue eyes.
+
+“Hello, Wilson, old man,” said Tom, slapping him jovially on the
+shoulder. “How’s business?”
+
+“I can’t complain,” answered Wilson unconvincingly. “When are you
+going to sell me that car?”
+
+“Next week; I’ve got my man working on it now.”
+
+“Works pretty slow, don’t he?”
+
+“No, he doesn’t,” said Tom coldly. “And if you feel that way about it,
+maybe I’d better sell it somewhere else after all.”
+
+“I don’t mean that,” explained Wilson quickly. “I just meant—”
+
+His voice faded off and Tom glanced impatiently around the garage.
+Then I heard footsteps on a stairs, and in a moment the thickish
+figure of a woman blocked out the light from the office door. She was
+in the middle thirties, and faintly stout, but she carried her flesh
+sensuously as some women can. Her face, above a spotted dress of dark
+blue crêpe-de-chine, contained no facet or gleam of beauty, but there
+was an immediately perceptible vitality about her as if the nerves of
+her body were continually smouldering. She smiled slowly and, walking
+through her husband as if he were a ghost, shook hands with Tom,
+looking him flush in the eye. Then she wet her lips, and without
+turning around spoke to her husband in a soft, coarse voice:
+
+“Get some chairs, why don’t you, so somebody can sit down.”
+
+“Oh, sure,” agreed Wilson hurriedly, and went toward the little
+office, mingling immediately with the cement colour of the walls. A
+white ashen dust veiled his dark suit and his pale hair as it veiled
+everything in the vicinity—except his wife, who moved close to Tom.
+
+“I want to see you,” said Tom intently. “Get on the next train.”
+
+“All right.”
+
+“I’ll meet you by the newsstand on the lower level.”
+
+She nodded and moved away from him just as George Wilson emerged with
+two chairs from his office door.
+
+We waited for her down the road and out of sight. It was a few days
+before the Fourth of July, and a grey, scrawny Italian child was
+setting torpedoes in a row along the railroad track.
+
+“Terrible place, isn’t it,” said Tom, exchanging a frown with Doctor
+Eckleburg.
+
+“Awful.”
+
+“It does her good to get away.”
+
+“Doesn’t her husband object?”
+
+“Wilson? He thinks she goes to see her sister in New York. He’s so
+dumb he doesn’t know he’s alive.”
+
+So Tom Buchanan and his girl and I went up together to New York—or not
+quite together, for Mrs. Wilson sat discreetly in another car. Tom
+deferred that much to the sensibilities of those East Eggers who might
+be on the train.
+
+She had changed her dress to a brown figured muslin, which stretched
+tight over her rather wide hips as Tom helped her to the platform in
+New York. At the newsstand she bought a copy of Town Tattle and a
+moving-picture magazine, and in the station drugstore some cold cream
+and a small flask of perfume. Upstairs, in the solemn echoing drive
+she let four taxicabs drive away before she selected a new one,
+lavender-coloured with grey upholstery, and in this we slid out from
+the mass of the station into the glowing sunshine. But immediately she
+turned sharply from the window and, leaning forward, tapped on the
+front glass.
+
+“I want to get one of those dogs,” she said earnestly. “I want to get
+one for the apartment. They’re nice to have—a dog.”
+
+We backed up to a grey old man who bore an absurd resemblance to John
+D. Rockefeller. In a basket swung from his neck cowered a dozen very
+recent puppies of an indeterminate breed.
+
+“What kind are they?” asked Mrs. Wilson eagerly, as he came to the
+taxi-window.
+
+“All kinds. What kind do you want, lady?”
+
+“I’d like to get one of those police dogs; I don’t suppose you got
+that kind?”
+
+The man peered doubtfully into the basket, plunged in his hand and
+drew one up, wriggling, by the back of the neck.
+
+“That’s no police dog,” said Tom.
+
+“No, it’s not exactly a police dog,” said the man with disappointment
+in his voice. “It’s more of an Airedale.” He passed his hand over the
+brown washrag of a back. “Look at that coat. Some coat. That’s a dog
+that’ll never bother you with catching cold.”
+
+“I think it’s cute,” said Mrs. Wilson enthusiastically. “How much is
+it?”
+
+“That dog?” He looked at it admiringly. “That dog will cost you ten
+dollars.”
+
+The Airedale—undoubtedly there was an Airedale concerned in it
+somewhere, though its feet were startlingly white—changed hands and
+settled down into Mrs. Wilson’s lap, where she fondled the
+weatherproof coat with rapture.
+
+“Is it a boy or a girl?” she asked delicately.
+
+“That dog? That dog’s a boy.”
+
+“It’s a bitch,” said Tom decisively. “Here’s your money. Go and buy
+ten more dogs with it.”
+
+We drove over to Fifth Avenue, warm and soft, almost pastoral, on the
+summer Sunday afternoon. I wouldn’t have been surprised to see a great
+flock of white sheep turn the corner.
+
+“Hold on,” I said, “I have to leave you here.”
+
+“No you don’t,” interposed Tom quickly. “Myrtle’ll be hurt if you
+don’t come up to the apartment. Won’t you, Myrtle?”
+
+“Come on,” she urged. “I’ll telephone my sister Catherine. She’s said
+to be very beautiful by people who ought to know.”
+
+“Well, I’d like to, but—”
+
+We went on, cutting back again over the Park toward the West Hundreds.
+At 158th Street the cab stopped at one slice in a long white cake of
+apartment-houses. Throwing a regal homecoming glance around the
+neighbourhood, Mrs. Wilson gathered up her dog and her other
+purchases, and went haughtily in.
+
+“I’m going to have the McKees come up,” she announced as we rose in
+the elevator. “And, of course, I got to call up my sister, too.”
+
+The apartment was on the top floor—a small living-room, a small
+dining-room, a small bedroom, and a bath. The living-room was crowded
+to the doors with a set of tapestried furniture entirely too large for
+it, so that to move about was to stumble continually over scenes of
+ladies swinging in the gardens of Versailles. The only picture was an
+over-enlarged photograph, apparently a hen sitting on a blurred rock.
+Looked at from a distance, however, the hen resolved itself into a
+bonnet, and the countenance of a stout old lady beamed down into the
+room. Several old copies of Town Tattle lay on the table together with
+a copy of Simon Called Peter, and some of the small scandal magazines
+of Broadway. Mrs. Wilson was first concerned with the dog. A reluctant
+elevator boy went for a box full of straw and some milk, to which he
+added on his own initiative a tin of large, hard dog biscuits—one of
+which decomposed apathetically in the saucer of milk all
+afternoon. Meanwhile Tom brought out a bottle of whisky from a locked
+bureau door.
+
+I have been drunk just twice in my life, and the second time was that
+afternoon; so everything that happened has a dim, hazy cast over it,
+although until after eight o’clock the apartment was full of cheerful
+sun. Sitting on Tom’s lap Mrs. Wilson called up several people on the
+telephone; then there were no cigarettes, and I went out to buy some
+at the drugstore on the corner. When I came back they had both
+disappeared, so I sat down discreetly in the living-room and read a
+chapter of Simon Called Peter—either it was terrible stuff or the
+whisky distorted things, because it didn’t make any sense to me.
+
+Just as Tom and Myrtle (after the first drink Mrs. Wilson and I called
+each other by our first names) reappeared, company commenced to arrive
+at the apartment door.
+
+The sister, Catherine, was a slender, worldly girl of about thirty,
+with a solid, sticky bob of red hair, and a complexion powdered milky
+white. Her eyebrows had been plucked and then drawn on again at a more
+rakish angle, but the efforts of nature toward the restoration of the
+old alignment gave a blurred air to her face. When she moved about
+there was an incessant clicking as innumerable pottery bracelets
+jingled up and down upon her arms. She came in with such a proprietary
+haste, and looked around so possessively at the furniture that I
+wondered if she lived here. But when I asked her she laughed
+immoderately, repeated my question aloud, and told me she lived with a
+girl friend at a hotel.
+
+Mr. McKee was a pale, feminine man from the flat below. He had just
+shaved, for there was a white spot of lather on his cheekbone, and he
+was most respectful in his greeting to everyone in the room. He
+informed me that he was in the “artistic game,” and I gathered later
+that he was a photographer and had made the dim enlargement of
+Mrs. Wilson’s mother which hovered like an ectoplasm on the wall. His
+wife was shrill, languid, handsome, and horrible. She told me with
+pride that her husband had photographed her a hundred and twenty-seven
+times since they had been married.
+
+Mrs. Wilson had changed her costume some time before, and was now
+attired in an elaborate afternoon dress of cream-coloured chiffon,
+which gave out a continual rustle as she swept about the room. With
+the influence of the dress her personality had also undergone a
+change. The intense vitality that had been so remarkable in the garage
+was converted into impressive hauteur. Her laughter, her gestures, her
+assertions became more violently affected moment by moment, and as she
+expanded the room grew smaller around her, until she seemed to be
+revolving on a noisy, creaking pivot through the smoky air.
+
+“My dear,” she told her sister in a high, mincing shout, “most of
+these fellas will cheat you every time. All they think of is money. I
+had a woman up here last week to look at my feet, and when she gave me
+the bill you’d of thought she had my appendicitis out.”
+
+“What was the name of the woman?” asked Mrs. McKee.
+
+“Mrs. Eberhardt. She goes around looking at people’s feet in their own
+homes.”
+
+“I like your dress,” remarked Mrs. McKee, “I think it’s adorable.”
+
+Mrs. Wilson rejected the compliment by raising her eyebrow in disdain.
+
+“It’s just a crazy old thing,” she said. “I just slip it on sometimes
+when I don’t care what I look like.”
+
+“But it looks wonderful on you, if you know what I mean,” pursued Mrs.
+McKee. “If Chester could only get you in that pose I think he could
+make something of it.”
+
+We all looked in silence at Mrs. Wilson, who removed a strand of hair
+from over her eyes and looked back at us with a brilliant smile. Mr.
+McKee regarded her intently with his head on one side, and then moved
+his hand back and forth slowly in front of his face.
+
+“I should change the light,” he said after a moment. “I’d like to
+bring out the modelling of the features. And I’d try to get hold of
+all the back hair.”
+
+“I wouldn’t think of changing the light,” cried Mrs. McKee. “I think
+it’s—”
+
+Her husband said “Sh!” and we all looked at the subject again,
+whereupon Tom Buchanan yawned audibly and got to his feet.
+
+“You McKees have something to drink,” he said. “Get some more ice and
+mineral water, Myrtle, before everybody goes to sleep.”
+
+“I told that boy about the ice.” Myrtle raised her eyebrows in despair
+at the shiftlessness of the lower orders. “These people! You have to
+keep after them all the time.”
+
+She looked at me and laughed pointlessly. Then she flounced over to
+the dog, kissed it with ecstasy, and swept into the kitchen, implying
+that a dozen chefs awaited her orders there.
+
+“I’ve done some nice things out on Long Island,” asserted Mr. McKee.
+
+Tom looked at him blankly.
+
+“Two of them we have framed downstairs.”
+
+“Two what?” demanded Tom.
+
+“Two studies. One of them I call Montauk Point—The Gulls, and the
+other I call Montauk Point—The Sea.”
+
+The sister Catherine sat down beside me on the couch.
+
+“Do you live down on Long Island, too?” she inquired.
+
+“I live at West Egg.”
+
+“Really? I was down there at a party about a month ago. At a man named
+Gatsby’s. Do you know him?”
+
+“I live next door to him.”
+
+“Well, they say he’s a nephew or a cousin of Kaiser Wilhelm’s. That’s
+where all his money comes from.”
+
+“Really?”
+
+She nodded.
+
+“I’m scared of him. I’d hate to have him get anything on me.”
+
+This absorbing information about my neighbour was interrupted by Mrs.
+McKee’s pointing suddenly at Catherine:
+
+“Chester, I think you could do something with her,” she broke out, but
+Mr. McKee only nodded in a bored way, and turned his attention to Tom.
+
+“I’d like to do more work on Long Island, if I could get the entry.
+All I ask is that they should give me a start.”
+
+“Ask Myrtle,” said Tom, breaking into a short shout of laughter as
+Mrs. Wilson entered with a tray. “She’ll give you a letter of
+introduction, won’t you, Myrtle?”
+
+“Do what?” she asked, startled.
+
+“You’ll give McKee a letter of introduction to your husband, so he can
+do some studies of him.” His lips moved silently for a moment as he
+invented, “ ‘George B. Wilson at the Gasoline Pump,’ or something like
+that.”
+
+Catherine leaned close to me and whispered in my ear:
+
+“Neither of them can stand the person they’re married to.”
+
+“Can’t they?”
+
+“Can’t stand them.” She looked at Myrtle and then at Tom. “What I say
+is, why go on living with them if they can’t stand them? If I was them
+I’d get a divorce and get married to each other right away.”
+
+“Doesn’t she like Wilson either?”
+
+The answer to this was unexpected. It came from Myrtle, who had
+overheard the question, and it was violent and obscene.
+
+“You see,” cried Catherine triumphantly. She lowered her voice again.
+“It’s really his wife that’s keeping them apart. She’s a Catholic, and
+they don’t believe in divorce.”
+
+Daisy was not a Catholic, and I was a little shocked at the
+elaborateness of the lie.
+
+“When they do get married,” continued Catherine, “they’re going West
+to live for a while until it blows over.”
+
+“It’d be more discreet to go to Europe.”
+
+“Oh, do you like Europe?” she exclaimed surprisingly. “I just got back
+from Monte Carlo.”
+
+“Really.”
+
+“Just last year. I went over there with another girl.”
+
+“Stay long?”
+
+“No, we just went to Monte Carlo and back. We went by way of
+Marseilles. We had over twelve hundred dollars when we started, but we
+got gyped out of it all in two days in the private rooms. We had an
+awful time getting back, I can tell you. God, how I hated that town!”
+
+The late afternoon sky bloomed in the window for a moment like the
+blue honey of the Mediterranean—then the shrill voice of Mrs. McKee
+called me back into the room.
+
+“I almost made a mistake, too,” she declared vigorously. “I almost
+married a little kike who’d been after me for years. I knew he was
+below me. Everybody kept saying to me: ‘Lucille, that man’s way below
+you!’ But if I hadn’t met Chester, he’d of got me sure.”
+
+“Yes, but listen,” said Myrtle Wilson, nodding her head up and down,
+“at least you didn’t marry him.”
+
+“I know I didn’t.”
+
+“Well, I married him,” said Myrtle, ambiguously. “And that’s the
+difference between your case and mine.”
+
+“Why did you, Myrtle?” demanded Catherine. “Nobody forced you to.”
+
+Myrtle considered.
+
+“I married him because I thought he was a gentleman,” she said
+finally. “I thought he knew something about breeding, but he wasn’t
+fit to lick my shoe.”
+
+“You were crazy about him for a while,” said Catherine.
+
+“Crazy about him!” cried Myrtle incredulously. “Who said I was crazy
+about him? I never was any more crazy about him than I was about that
+man there.”
+
+She pointed suddenly at me, and everyone looked at me accusingly. I
+tried to show by my expression that I expected no affection.
+
+“The only crazy I was was when I married him. I knew right away I made
+a mistake. He borrowed somebody’s best suit to get married in, and
+never even told me about it, and the man came after it one day when he
+was out: ‘Oh, is that your suit?’ I said. ‘This is the first I ever
+heard about it.’ But I gave it to him and then I lay down and cried to
+beat the band all afternoon.”
+
+“She really ought to get away from him,” resumed Catherine to me.
+“They’ve been living over that garage for eleven years. And Tom’s the
+first sweetie she ever had.”
+
+The bottle of whisky—a second one—was now in constant demand by all
+present, excepting Catherine, who “felt just as good on nothing at
+all.” Tom rang for the janitor and sent him for some celebrated
+sandwiches, which were a complete supper in themselves. I wanted to
+get out and walk eastward toward the park through the soft twilight,
+but each time I tried to go I became entangled in some wild, strident
+argument which pulled me back, as if with ropes, into my chair. Yet
+high over the city our line of yellow windows must have contributed
+their share of human secrecy to the casual watcher in the darkening
+streets, and I saw him too, looking up and wondering. I was within and
+without, simultaneously enchanted and repelled by the inexhaustible
+variety of life.
+
+Myrtle pulled her chair close to mine, and suddenly her warm breath
+poured over me the story of her first meeting with Tom.
+
+“It was on the two little seats facing each other that are always the
+last ones left on the train. I was going up to New York to see my
+sister and spend the night. He had on a dress suit and patent leather
+shoes, and I couldn’t keep my eyes off him, but every time he looked
+at me I had to pretend to be looking at the advertisement over his
+head. When we came into the station he was next to me, and his white
+shirtfront pressed against my arm, and so I told him I’d have to call
+a policeman, but he knew I lied. I was so excited that when I got into
+a taxi with him I didn’t hardly know I wasn’t getting into a subway
+train. All I kept thinking about, over and over, was ‘You can’t live
+forever; you can’t live forever.’ ”
+
+She turned to Mrs. McKee and the room rang full of her artificial
+laughter.
+
+“My dear,” she cried, “I’m going to give you this dress as soon as I’m
+through with it. I’ve got to get another one tomorrow. I’m going to
+make a list of all the things I’ve got to get. A massage and a wave,
+and a collar for the dog, and one of those cute little ashtrays where
+you touch a spring, and a wreath with a black silk bow for mother’s
+grave that’ll last all summer. I got to write down a list so I won’t
+forget all the things I got to do.”
+
+It was nine o’clock—almost immediately afterward I looked at my watch
+and found it was ten. Mr. McKee was asleep on a chair with his fists
+clenched in his lap, like a photograph of a man of action. Taking out
+my handkerchief I wiped from his cheek the spot of dried lather that
+had worried me all the afternoon.
+
+The little dog was sitting on the table looking with blind eyes
+through the smoke, and from time to time groaning faintly. People
+disappeared, reappeared, made plans to go somewhere, and then lost
+each other, searched for each other, found each other a few feet
+away. Some time toward midnight Tom Buchanan and Mrs. Wilson stood
+face to face discussing, in impassioned voices, whether Mrs. Wilson
+had any right to mention Daisy’s name.
+
+“Daisy! Daisy! Daisy!” shouted Mrs. Wilson. “I’ll say it whenever I
+want to! Daisy! Dai—”
+
+Making a short deft movement, Tom Buchanan broke her nose with his
+open hand.
+
+Then there were bloody towels upon the bathroom floor, and women’s
+voices scolding, and high over the confusion a long broken wail of
+pain. Mr. McKee awoke from his doze and started in a daze toward the
+door. When he had gone halfway he turned around and stared at the
+scene—his wife and Catherine scolding and consoling as they stumbled
+here and there among the crowded furniture with articles of aid, and
+the despairing figure on the couch, bleeding fluently, and trying to
+spread a copy of Town Tattle over the tapestry scenes of
+Versailles. Then Mr. McKee turned and continued on out the door.
+Taking my hat from the chandelier, I followed.
+
+“Come to lunch some day,” he suggested, as we groaned down in the
+elevator.
+
+“Where?”
+
+“Anywhere.”
+
+“Keep your hands off the lever,” snapped the elevator boy.
+
+“I beg your pardon,” said Mr. McKee with dignity, “I didn’t know I was
+touching it.”
+
+“All right,” I agreed, “I’ll be glad to.”
+
+… I was standing beside his bed and he was sitting up between the
+sheets, clad in his underwear, with a great portfolio in his hands.
+
+“Beauty and the Beast … Loneliness … Old Grocery Horse … Brook’n
+Bridge …”
+
+Then I was lying half asleep in the cold lower level of the
+Pennsylvania Station, staring at the morning Tribune, and waiting for
+the four o’clock train.
+
+
+                                 III
+
+There was music from my neighbour’s house through the summer nights.
+In his blue gardens men and girls came and went like moths among the
+whisperings and the champagne and the stars. At high tide in the
+afternoon I watched his guests diving from the tower of his raft, or
+taking the sun on the hot sand of his beach while his two motorboats
+slit the waters of the Sound, drawing aquaplanes over cataracts of
+foam. On weekends his Rolls-Royce became an omnibus, bearing parties
+to and from the city between nine in the morning and long past
+midnight, while his station wagon scampered like a brisk yellow bug to
+meet all trains. And on Mondays eight servants, including an extra
+gardener, toiled all day with mops and scrubbing-brushes and hammers
+and garden-shears, repairing the ravages of the night before.
+
+Every Friday five crates of oranges and lemons arrived from a
+fruiterer in New York—every Monday these same oranges and lemons left
+his back door in a pyramid of pulpless halves. There was a machine in
+the kitchen which could extract the juice of two hundred oranges in
+half an hour if a little button was pressed two hundred times by a
+butler’s thumb.
+
+At least once a fortnight a corps of caterers came down with several
+hundred feet of canvas and enough coloured lights to make a Christmas
+tree of Gatsby’s enormous garden. On buffet tables, garnished with
+glistening hors-d’oeuvre, spiced baked hams crowded against salads of
+harlequin designs and pastry pigs and turkeys bewitched to a dark
+gold. In the main hall a bar with a real brass rail was set up, and
+stocked with gins and liquors and with cordials so long forgotten that
+most of his female guests were too young to know one from another.
+
+By seven o’clock the orchestra has arrived, no thin five-piece affair,
+but a whole pitful of oboes and trombones and saxophones and viols and
+cornets and piccolos, and low and high drums. The last swimmers have
+come in from the beach now and are dressing upstairs; the cars from
+New York are parked five deep in the drive, and already the halls and
+salons and verandas are gaudy with primary colours, and hair bobbed in
+strange new ways, and shawls beyond the dreams of Castile. The bar is
+in full swing, and floating rounds of cocktails permeate the garden
+outside, until the air is alive with chatter and laughter, and casual
+innuendo and introductions forgotten on the spot, and enthusiastic
+meetings between women who never knew each other’s names.
+
+The lights grow brighter as the earth lurches away from the sun, and
+now the orchestra is playing yellow cocktail music, and the opera of
+voices pitches a key higher. Laughter is easier minute by minute,
+spilled with prodigality, tipped out at a cheerful word. The groups
+change more swiftly, swell with new arrivals, dissolve and form in the
+same breath; already there are wanderers, confident girls who weave
+here and there among the stouter and more stable, become for a sharp,
+joyous moment the centre of a group, and then, excited with triumph,
+glide on through the sea-change of faces and voices and colour under
+the constantly changing light.
+
+Suddenly one of these gypsies, in trembling opal, seizes a cocktail
+out of the air, dumps it down for courage and, moving her hands like
+Frisco, dances out alone on the canvas platform. A momentary hush; the
+orchestra leader varies his rhythm obligingly for her, and there is a
+burst of chatter as the erroneous news goes around that she is Gilda
+Gray’s understudy from the Follies. The party has begun.
+
+I believe that on the first night I went to Gatsby’s house I was one
+of the few guests who had actually been invited. People were not
+invited—they went there. They got into automobiles which bore them out
+to Long Island, and somehow they ended up at Gatsby’s door. Once there
+they were introduced by somebody who knew Gatsby, and after that they
+conducted themselves according to the rules of behaviour associated
+with an amusement park. Sometimes they came and went without having
+met Gatsby at all, came for the party with a simplicity of heart that
+was its own ticket of admission.
+
+I had been actually invited. A chauffeur in a uniform of robin’s-egg
+blue crossed my lawn early that Saturday morning with a surprisingly
+formal note from his employer: the honour would be entirely Gatsby’s,
+it said, if I would attend his “little party” that night. He had seen
+me several times, and had intended to call on me long before, but a
+peculiar combination of circumstances had prevented it—signed Jay
+Gatsby, in a majestic hand.
+
+Dressed up in white flannels I went over to his lawn a little after
+seven, and wandered around rather ill at ease among swirls and eddies
+of people I didn’t know—though here and there was a face I had noticed
+on the commuting train. I was immediately struck by the number of
+young Englishmen dotted about; all well dressed, all looking a little
+hungry, and all talking in low, earnest voices to solid and prosperous
+Americans. I was sure that they were selling something: bonds or
+insurance or automobiles. They were at least agonizingly aware of the
+easy money in the vicinity and convinced that it was theirs for a few
+words in the right key.
+
+As soon as I arrived I made an attempt to find my host, but the two or
+three people of whom I asked his whereabouts stared at me in such an
+amazed way, and denied so vehemently any knowledge of his movements,
+that I slunk off in the direction of the cocktail table—the only place
+in the garden where a single man could linger without looking
+purposeless and alone.
+
+I was on my way to get roaring drunk from sheer embarrassment when
+Jordan Baker came out of the house and stood at the head of the marble
+steps, leaning a little backward and looking with contemptuous
+interest down into the garden.
+
+Welcome or not, I found it necessary to attach myself to someone
+before I should begin to address cordial remarks to the passersby.
+
+“Hello!” I roared, advancing toward her. My voice seemed unnaturally
+loud across the garden.
+
+“I thought you might be here,” she responded absently as I came up.
+“I remembered you lived next door to—”
+
+She held my hand impersonally, as a promise that she’d take care of me
+in a minute, and gave ear to two girls in twin yellow dresses, who
+stopped at the foot of the steps.
+
+“Hello!” they cried together. “Sorry you didn’t win.”
+
+That was for the golf tournament. She had lost in the finals the week
+before.
+
+“You don’t know who we are,” said one of the girls in yellow, “but we
+met you here about a month ago.”
+
+“You’ve dyed your hair since then,” remarked Jordan, and I started,
+but the girls had moved casually on and her remark was addressed to
+the premature moon, produced like the supper, no doubt, out of a
+caterer’s basket. With Jordan’s slender golden arm resting in mine, we
+descended the steps and sauntered about the garden. A tray of
+cocktails floated at us through the twilight, and we sat down at a
+table with the two girls in yellow and three men, each one introduced
+to us as Mr. Mumble.
+
+“Do you come to these parties often?” inquired Jordan of the girl
+beside her.
+
+“The last one was the one I met you at,” answered the girl, in an
+alert confident voice. She turned to her companion: “Wasn’t it for
+you, Lucille?”
+
+It was for Lucille, too.
+
+“I like to come,” Lucille said. “I never care what I do, so I always
+have a good time. When I was here last I tore my gown on a chair, and
+he asked me my name and address—inside of a week I got a package from
+Croirier’s with a new evening gown in it.”
+
+“Did you keep it?” asked Jordan.
+
+“Sure I did. I was going to wear it tonight, but it was too big in the
+bust and had to be altered. It was gas blue with lavender beads. Two
+hundred and sixty-five dollars.”
+
+“There’s something funny about a fellow that’ll do a thing like that,”
+said the other girl eagerly. “He doesn’t want any trouble with
+anybody.”
+
+“Who doesn’t?” I inquired.
+
+“Gatsby. Somebody told me—”
+
+The two girls and Jordan leaned together confidentially.
+
+“Somebody told me they thought he killed a man once.”
+
+A thrill passed over all of us. The three Mr. Mumbles bent forward and
+listened eagerly.
+
+“I don’t think it’s so much that,” argued Lucille sceptically; “It’s
+more that he was a German spy during the war.”
+
+One of the men nodded in confirmation.
+
+“I heard that from a man who knew all about him, grew up with him in
+Germany,” he assured us positively.
+
+“Oh, no,” said the first girl, “it couldn’t be that, because he was in
+the American army during the war.” As our credulity switched back to
+her she leaned forward with enthusiasm. “You look at him sometimes
+when he thinks nobody’s looking at him. I’ll bet he killed a man.”
+
+She narrowed her eyes and shivered. Lucille shivered. We all turned
+and looked around for Gatsby. It was testimony to the romantic
+speculation he inspired that there were whispers about him from those
+who had found little that it was necessary to whisper about in this
+world.
+
+The first supper—there would be another one after midnight—was now
+being served, and Jordan invited me to join her own party, who were
+spread around a table on the other side of the garden. There were
+three married couples and Jordan’s escort, a persistent undergraduate
+given to violent innuendo, and obviously under the impression that
+sooner or later Jordan was going to yield him up her person to a
+greater or lesser degree. Instead of rambling, this party had
+preserved a dignified homogeneity, and assumed to itself the function
+of representing the staid nobility of the countryside—East Egg
+condescending to West Egg and carefully on guard against its
+spectroscopic gaiety.
+
+“Let’s get out,” whispered Jordan, after a somehow wasteful and
+inappropriate half-hour; “this is much too polite for me.”
+
+We got up, and she explained that we were going to find the host: I
+had never met him, she said, and it was making me uneasy. The
+undergraduate nodded in a cynical, melancholy way.
+
+The bar, where we glanced first, was crowded, but Gatsby was not
+there. She couldn’t find him from the top of the steps, and he wasn’t
+on the veranda. On a chance we tried an important-looking door, and
+walked into a high Gothic library, panelled with carved English oak,
+and probably transported complete from some ruin overseas.
+
+A stout, middle-aged man, with enormous owl-eyed spectacles, was
+sitting somewhat drunk on the edge of a great table, staring with
+unsteady concentration at the shelves of books. As we entered he
+wheeled excitedly around and examined Jordan from head to foot.
+
+“What do you think?” he demanded impetuously.
+
+“About what?”
+
+He waved his hand toward the bookshelves.
+
+“About that. As a matter of fact you needn’t bother to ascertain. I
+ascertained. They’re real.”
+
+“The books?”
+
+He nodded.
+
+“Absolutely real—have pages and everything. I thought they’d be a nice
+durable cardboard. Matter of fact, they’re absolutely real.  Pages
+and—Here! Lemme show you.”
+
+Taking our scepticism for granted, he rushed to the bookcases and
+returned with Volume One of the Stoddard Lectures.
+
+“See!” he cried triumphantly. “It’s a bona-fide piece of printed
+matter. It fooled me. This fella’s a regular Belasco. It’s a
+triumph. What thoroughness! What realism! Knew when to stop,
+too—didn’t cut the pages. But what do you want? What do you expect?”
+
+He snatched the book from me and replaced it hastily on its shelf,
+muttering that if one brick was removed the whole library was liable
+to collapse.
+
+“Who brought you?” he demanded. “Or did you just come? I was brought.
+Most people were brought.”
+
+Jordan looked at him alertly, cheerfully, without answering.
+
+“I was brought by a woman named Roosevelt,” he continued. “Mrs. Claud
+Roosevelt. Do you know her? I met her somewhere last night. I’ve been
+drunk for about a week now, and I thought it might sober me up to sit
+in a library.”
+
+“Has it?”
+
+“A little bit, I think. I can’t tell yet. I’ve only been here an hour.
+Did I tell you about the books? They’re real. They’re—”
+
+“You told us.”
+
+We shook hands with him gravely and went back outdoors.
+
+There was dancing now on the canvas in the garden; old men pushing
+young girls backward in eternal graceless circles, superior couples
+holding each other tortuously, fashionably, and keeping in the
+corners—and a great number of single girls dancing individually or
+relieving the orchestra for a moment of the burden of the banjo or the
+traps. By midnight the hilarity had increased. A celebrated tenor had
+sung in Italian, and a notorious contralto had sung in jazz, and
+between the numbers people were doing “stunts” all over the garden,
+while happy, vacuous bursts of laughter rose toward the summer sky. A
+pair of stage twins, who turned out to be the girls in yellow, did a
+baby act in costume, and champagne was served in glasses bigger than
+finger-bowls. The moon had risen higher, and floating in the Sound was
+a triangle of silver scales, trembling a little to the stiff, tinny
+drip of the banjoes on the lawn.
+
+I was still with Jordan Baker. We were sitting at a table with a man
+of about my age and a rowdy little girl, who gave way upon the
+slightest provocation to uncontrollable laughter. I was enjoying
+myself now. I had taken two finger-bowls of champagne, and the scene
+had changed before my eyes into something significant, elemental, and
+profound.
+
+At a lull in the entertainment the man looked at me and smiled.
+
+“Your face is familiar,” he said politely. “Weren’t you in the First
+Division during the war?”
+
+“Why yes. I was in the Twenty-eighth Infantry.”
+
+“I was in the Sixteenth until June nineteen-eighteen. I knew I’d seen
+you somewhere before.”
+
+We talked for a moment about some wet, grey little villages in France.
+Evidently he lived in this vicinity, for he told me that he had just
+bought a hydroplane, and was going to try it out in the morning.
+
+“Want to go with me, old sport? Just near the shore along the Sound.”
+
+“What time?”
+
+“Any time that suits you best.”
+
+It was on the tip of my tongue to ask his name when Jordan looked
+around and smiled.
+
+“Having a gay time now?” she inquired.
+
+“Much better.” I turned again to my new acquaintance. “This is an
+unusual party for me. I haven’t even seen the host. I live over
+there—” I waved my hand at the invisible hedge in the distance, “and
+this man Gatsby sent over his chauffeur with an invitation.”
+
+For a moment he looked at me as if he failed to understand.
+
+“I’m Gatsby,” he said suddenly.
+
+“What!” I exclaimed. “Oh, I beg your pardon.”
+
+“I thought you knew, old sport. I’m afraid I’m not a very good host.”
+
+He smiled understandingly—much more than understandingly. It was one
+of those rare smiles with a quality of eternal reassurance in it, that
+you may come across four or five times in life. It faced—or seemed to
+face—the whole eternal world for an instant, and then concentrated on
+you with an irresistible prejudice in your favour. It understood you
+just so far as you wanted to be understood, believed in you as you
+would like to believe in yourself, and assured you that it had
+precisely the impression of you that, at your best, you hoped to
+convey. Precisely at that point it vanished—and I was looking at an
+elegant young roughneck, a year or two over thirty, whose elaborate
+formality of speech just missed being absurd. Some time before he
+introduced himself I’d got a strong impression that he was picking his
+words with care.
+
+Almost at the moment when Mr. Gatsby identified himself a butler
+hurried toward him with the information that Chicago was calling him
+on the wire. He excused himself with a small bow that included each of
+us in turn.
+
+“If you want anything just ask for it, old sport,” he urged me.
+“Excuse me. I will rejoin you later.”
+
+When he was gone I turned immediately to Jordan—constrained to assure
+her of my surprise. I had expected that Mr. Gatsby would be a florid
+and corpulent person in his middle years.
+
+“Who is he?” I demanded. “Do you know?”
+
+“He’s just a man named Gatsby.”
+
+“Where is he from, I mean? And what does he do?”
+
+“Now you’re started on the subject,” she answered with a wan smile.
+“Well, he told me once he was an Oxford man.”
+
+A dim background started to take shape behind him, but at her next
+remark it faded away.
+
+“However, I don’t believe it.”
+
+“Why not?”
+
+“I don’t know,” she insisted, “I just don’t think he went there.”
+
+Something in her tone reminded me of the other girl’s “I think he
+killed a man,” and had the effect of stimulating my curiosity. I would
+have accepted without question the information that Gatsby sprang from
+the swamps of Louisiana or from the lower East Side of New York. That
+was comprehensible. But young men didn’t—at least in my provincial
+inexperience I believed they didn’t—drift coolly out of nowhere and
+buy a palace on Long Island Sound.
+
+“Anyhow, he gives large parties,” said Jordan, changing the subject
+with an urban distaste for the concrete. “And I like large parties.
+They’re so intimate. At small parties there isn’t any privacy.”
+
+There was the boom of a bass drum, and the voice of the orchestra
+leader rang out suddenly above the echolalia of the garden.
+
+“Ladies and gentlemen,” he cried. “At the request of Mr. Gatsby we are
+going to play for you Mr. Vladmir Tostoff’s latest work, which
+attracted so much attention at Carnegie Hall last May. If you read the
+papers you know there was a big sensation.” He smiled with jovial
+condescension, and added: “Some sensation!” Whereupon everybody
+laughed.
+
+“The piece is known,” he concluded lustily, “as ‘Vladmir Tostoff’s
+Jazz History of the World!’ ”
+
+The nature of Mr. Tostoff’s composition eluded me, because just as it
+began my eyes fell on Gatsby, standing alone on the marble steps and
+looking from one group to another with approving eyes. His tanned skin
+was drawn attractively tight on his face and his short hair looked as
+though it were trimmed every day. I could see nothing sinister about
+him. I wondered if the fact that he was not drinking helped to set him
+off from his guests, for it seemed to me that he grew more correct as
+the fraternal hilarity increased. When the “Jazz History of the World”
+was over, girls were putting their heads on men’s shoulders in a
+puppyish, convivial way, girls were swooning backward playfully into
+men’s arms, even into groups, knowing that someone would arrest their
+falls—but no one swooned backward on Gatsby, and no French bob touched
+Gatsby’s shoulder, and no singing quartets were formed with Gatsby’s
+head for one link.
+
+“I beg your pardon.”
+
+Gatsby’s butler was suddenly standing beside us.
+
+“Miss Baker?” he inquired. “I beg your pardon, but Mr. Gatsby would
+like to speak to you alone.”
+
+“With me?” she exclaimed in surprise.
+
+“Yes, madame.”
+
+She got up slowly, raising her eyebrows at me in astonishment, and
+followed the butler toward the house. I noticed that she wore her
+evening-dress, all her dresses, like sports clothes—there was a
+jauntiness about her movements as if she had first learned to walk
+upon golf courses on clean, crisp mornings.
+
+I was alone and it was almost two. For some time confused and
+intriguing sounds had issued from a long, many-windowed room which
+overhung the terrace. Eluding Jordan’s undergraduate, who was now
+engaged in an obstetrical conversation with two chorus girls, and who
+implored me to join him, I went inside.
+
+The large room was full of people. One of the girls in yellow was
+playing the piano, and beside her stood a tall, red-haired young lady
+from a famous chorus, engaged in song. She had drunk a quantity of
+champagne, and during the course of her song she had decided, ineptly,
+that everything was very, very sad—she was not only singing, she was
+weeping too. Whenever there was a pause in the song she filled it with
+gasping, broken sobs, and then took up the lyric again in a quavering
+soprano. The tears coursed down her cheeks—not freely, however, for
+when they came into contact with her heavily beaded eyelashes they
+assumed an inky colour, and pursued the rest of their way in slow
+black rivulets. A humorous suggestion was made that she sing the notes
+on her face, whereupon she threw up her hands, sank into a chair, and
+went off into a deep vinous sleep.
+
+“She had a fight with a man who says he’s her husband,” explained a
+girl at my elbow.
+
+I looked around. Most of the remaining women were now having fights
+with men said to be their husbands. Even Jordan’s party, the quartet
+from East Egg, were rent asunder by dissension. One of the men was
+talking with curious intensity to a young actress, and his wife, after
+attempting to laugh at the situation in a dignified and indifferent
+way, broke down entirely and resorted to flank attacks—at intervals
+she appeared suddenly at his side like an angry diamond, and hissed:
+“You promised!” into his ear.
+
+The reluctance to go home was not confined to wayward men. The hall
+was at present occupied by two deplorably sober men and their highly
+indignant wives. The wives were sympathizing with each other in
+slightly raised voices.
+
+“Whenever he sees I’m having a good time he wants to go home.”
+
+“Never heard anything so selfish in my life.”
+
+“We’re always the first ones to leave.”
+
+“So are we.”
+
+“Well, we’re almost the last tonight,” said one of the men sheepishly.
+“The orchestra left half an hour ago.”
+
+In spite of the wives’ agreement that such malevolence was beyond
+credibility, the dispute ended in a short struggle, and both wives
+were lifted, kicking, into the night.
+
+As I waited for my hat in the hall the door of the library opened and
+Jordan Baker and Gatsby came out together. He was saying some last
+word to her, but the eagerness in his manner tightened abruptly into
+formality as several people approached him to say goodbye.
+
+Jordan’s party were calling impatiently to her from the porch, but she
+lingered for a moment to shake hands.
+
+“I’ve just heard the most amazing thing,” she whispered. “How long
+were we in there?”
+
+“Why, about an hour.”
+
+“It was … simply amazing,” she repeated abstractedly. “But I swore I
+wouldn’t tell it and here I am tantalizing you.” She yawned gracefully
+in my face. “Please come and see me … Phone book … Under the name of
+Mrs. Sigourney Howard … My aunt …” She was hurrying off as she
+talked—her brown hand waved a jaunty salute as she melted into her
+party at the door.
+
+Rather ashamed that on my first appearance I had stayed so late, I
+joined the last of Gatsby’s guests, who were clustered around him. I
+wanted to explain that I’d hunted for him early in the evening and to
+apologize for not having known him in the garden.
+
+“Don’t mention it,” he enjoined me eagerly. “Don’t give it another
+thought, old sport.” The familiar expression held no more familiarity
+than the hand which reassuringly brushed my shoulder. “And don’t
+forget we’re going up in the hydroplane tomorrow morning, at nine
+o’clock.”
+
+Then the butler, behind his shoulder:
+
+“Philadelphia wants you on the phone, sir.”
+
+“All right, in a minute. Tell them I’ll be right there … Good night.”
+
+“Good night.”
+
+“Good night.” He smiled—and suddenly there seemed to be a pleasant
+significance in having been among the last to go, as if he had desired
+it all the time. “Good night, old sport … Good night.”
+
+But as I walked down the steps I saw that the evening was not quite
+over. Fifty feet from the door a dozen headlights illuminated a
+bizarre and tumultuous scene. In the ditch beside the road, right side
+up, but violently shorn of one wheel, rested a new coupé which had
+left Gatsby’s drive not two minutes before. The sharp jut of a wall
+accounted for the detachment of the wheel, which was now getting
+considerable attention from half a dozen curious chauffeurs. However,
+as they had left their cars blocking the road, a harsh, discordant din
+from those in the rear had been audible for some time, and added to
+the already violent confusion of the scene.
+
+A man in a long duster had dismounted from the wreck and now stood in
+the middle of the road, looking from the car to the tyre and from the
+tyre to the observers in a pleasant, puzzled way.
+
+“See!” he explained. “It went in the ditch.”
+
+The fact was infinitely astonishing to him, and I recognized first the
+unusual quality of wonder, and then the man—it was the late patron of
+Gatsby’s library.
+
+“How’d it happen?”
+
+He shrugged his shoulders.
+
+“I know nothing whatever about mechanics,” he said decisively.
+
+“But how did it happen? Did you run into the wall?”
+
+“Don’t ask me,” said Owl Eyes, washing his hands of the whole
+matter. “I know very little about driving—next to nothing. It
+happened, and that’s all I know.”
+
+“Well, if you’re a poor driver you oughtn’t to try driving at night.”
+
+“But I wasn’t even trying,” he explained indignantly, “I wasn’t even
+trying.”
+
+An awed hush fell upon the bystanders.
+
+“Do you want to commit suicide?”
+
+“You’re lucky it was just a wheel! A bad driver and not even trying!”
+
+“You don’t understand,” explained the criminal. “I wasn’t driving.
+There’s another man in the car.”
+
+The shock that followed this declaration found voice in a sustained
+“Ah-h-h!” as the door of the coupé swung slowly open. The crowd—it was
+now a crowd—stepped back involuntarily, and when the door had opened
+wide there was a ghostly pause. Then, very gradually, part by part, a
+pale, dangling individual stepped out of the wreck, pawing tentatively
+at the ground with a large uncertain dancing shoe.
+
+Blinded by the glare of the headlights and confused by the incessant
+groaning of the horns, the apparition stood swaying for a moment
+before he perceived the man in the duster.
+
+“Wha’s matter?” he inquired calmly. “Did we run outa gas?”
+
+“Look!”
+
+Half a dozen fingers pointed at the amputated wheel—he stared at it
+for a moment, and then looked upward as though he suspected that it
+had dropped from the sky.
+
+“It came off,” someone explained.
+
+He nodded.
+
+“At first I din’ notice we’d stopped.”
+
+A pause. Then, taking a long breath and straightening his shoulders,
+he remarked in a determined voice:
+
+“Wonder’ff tell me where there’s a gas’line station?”
+
+At least a dozen men, some of them a little better off than he was,
+explained to him that wheel and car were no longer joined by any
+physical bond.
+
+“Back out,” he suggested after a moment. “Put her in reverse.”
+
+“But the wheel’s off!”
+
+He hesitated.
+
+“No harm in trying,” he said.
+
+The caterwauling horns had reached a crescendo and I turned away and
+cut across the lawn toward home. I glanced back once. A wafer of a
+moon was shining over Gatsby’s house, making the night fine as before,
+and surviving the laughter and the sound of his still glowing garden.
+A sudden emptiness seemed to flow now from the windows and the great
+doors, endowing with complete isolation the figure of the host, who
+stood on the porch, his hand up in a formal gesture of farewell.
+
+------------------------------------------------------------------------
+
+Reading over what I have written so far, I see I have given the
+impression that the events of three nights several weeks apart were
+all that absorbed me. On the contrary, they were merely casual events
+in a crowded summer, and, until much later, they absorbed me
+infinitely less than my personal affairs.
+
+Most of the time I worked. In the early morning the sun threw my
+shadow westward as I hurried down the white chasms of lower New York
+to the Probity Trust. I knew the other clerks and young bond-salesmen
+by their first names, and lunched with them in dark, crowded
+restaurants on little pig sausages and mashed potatoes and coffee. I
+even had a short affair with a girl who lived in Jersey City and
+worked in the accounting department, but her brother began throwing
+mean looks in my direction, so when she went on her vacation in July I
+let it blow quietly away.
+
+I took dinner usually at the Yale Club—for some reason it was the
+gloomiest event of my day—and then I went upstairs to the library and
+studied investments and securities for a conscientious hour. There
+were generally a few rioters around, but they never came into the
+library, so it was a good place to work. After that, if the night was
+mellow, I strolled down Madison Avenue past the old Murray Hill Hotel,
+and over 33rd Street to the Pennsylvania Station.
+
+I began to like New York, the racy, adventurous feel of it at night,
+and the satisfaction that the constant flicker of men and women and
+machines gives to the restless eye. I liked to walk up Fifth Avenue
+and pick out romantic women from the crowd and imagine that in a few
+minutes I was going to enter into their lives, and no one would ever
+know or disapprove. Sometimes, in my mind, I followed them to their
+apartments on the corners of hidden streets, and they turned and
+smiled back at me before they faded through a door into warm
+darkness. At the enchanted metropolitan twilight I felt a haunting
+loneliness sometimes, and felt it in others—poor young clerks who
+loitered in front of windows waiting until it was time for a solitary
+restaurant dinner—young clerks in the dusk, wasting the most poignant
+moments of night and life.
+
+Again at eight o’clock, when the dark lanes of the Forties were lined
+five deep with throbbing taxicabs, bound for the theatre district, I
+felt a sinking in my heart. Forms leaned together in the taxis as they
+waited, and voices sang, and there was laughter from unheard jokes,
+and lighted cigarettes made unintelligible circles inside. Imagining
+that I, too, was hurrying towards gaiety and sharing their intimate
+excitement, I wished them well.
+
+For a while I lost sight of Jordan Baker, and then in midsummer I
+found her again. At first I was flattered to go places with her,
+because she was a golf champion, and everyone knew her name. Then it
+was something more. I wasn’t actually in love, but I felt a sort of
+tender curiosity. The bored haughty face that she turned to the world
+concealed something—most affectations conceal something eventually,
+even though they don’t in the beginning—and one day I found what it
+was. When we were on a house-party together up in Warwick, she left a
+borrowed car out in the rain with the top down, and then lied about
+it—and suddenly I remembered the story about her that had eluded me
+that night at Daisy’s. At her first big golf tournament there was a
+row that nearly reached the newspapers—a suggestion that she had moved
+her ball from a bad lie in the semifinal round. The thing approached
+the proportions of a scandal—then died away. A caddy retracted his
+statement, and the only other witness admitted that he might have been
+mistaken. The incident and the name had remained together in my mind.
+
+Jordan Baker instinctively avoided clever, shrewd men, and now I saw
+that this was because she felt safer on a plane where any divergence
+from a code would be thought impossible. She was incurably dishonest.
+She wasn’t able to endure being at a disadvantage and, given this
+unwillingness, I suppose she had begun dealing in subterfuges when she
+was very young in order to keep that cool, insolent smile turned to
+the world and yet satisfy the demands of her hard, jaunty body.
+
+It made no difference to me. Dishonesty in a woman is a thing you
+never blame deeply—I was casually sorry, and then I forgot. It was on
+that same house-party that we had a curious conversation about driving
+a car. It started because she passed so close to some workmen that our
+fender flicked a button on one man’s coat.
+
+“You’re a rotten driver,” I protested. “Either you ought to be more
+careful, or you oughtn’t to drive at all.”
+
+“I am careful.”
+
+“No, you’re not.”
+
+“Well, other people are,” she said lightly.
+
+“What’s that got to do with it?”
+
+“They’ll keep out of my way,” she insisted. “It takes two to make an
+accident.”
+
+“Suppose you met somebody just as careless as yourself.”
+
+“I hope I never will,” she answered. “I hate careless people. That’s
+why I like you.”
+
+Her grey, sun-strained eyes stared straight ahead, but she had
+deliberately shifted our relations, and for a moment I thought I loved
+her. But I am slow-thinking and full of interior rules that act as
+brakes on my desires, and I knew that first I had to get myself
+definitely out of that tangle back home. I’d been writing letters once
+a week and signing them: “Love, Nick,” and all I could think of was
+how, when that certain girl played tennis, a faint moustache of
+perspiration appeared on her upper lip. Nevertheless there was a vague
+understanding that had to be tactfully broken off before I was free.
+
+Everyone suspects himself of at least one of the cardinal virtues, and
+this is mine: I am one of the few honest people that I have ever
+known.
+
+
+                                  IV
+
+On Sunday morning while church bells rang in the villages alongshore,
+the world and its mistress returned to Gatsby’s house and twinkled
+hilariously on his lawn.
+
+“He’s a bootlegger,” said the young ladies, moving somewhere between
+his cocktails and his flowers. “One time he killed a man who had found
+out that he was nephew to Von Hindenburg and second cousin to the
+devil. Reach me a rose, honey, and pour me a last drop into that there
+crystal glass.”
+
+Once I wrote down on the empty spaces of a timetable the names of
+those who came to Gatsby’s house that summer. It is an old timetable
+now, disintegrating at its folds, and headed “This schedule in effect
+July 5th, 1922.” But I can still read the grey names, and they will
+give you a better impression than my generalities of those who
+accepted Gatsby’s hospitality and paid him the subtle tribute of
+knowing nothing whatever about him.
+
+From East Egg, then, came the Chester Beckers and the Leeches, and a
+man named Bunsen, whom I knew at Yale, and Doctor Webster Civet, who
+was drowned last summer up in Maine. And the Hornbeams and the Willie
+Voltaires, and a whole clan named Blackbuck, who always gathered in a
+corner and flipped up their noses like goats at whosoever came
+near. And the Ismays and the Chrysties (or rather Hubert Auerbach and
+Mr. Chrystie’s wife), and Edgar Beaver, whose hair, they say, turned
+cotton-white one winter afternoon for no good reason at all.
+
+Clarence Endive was from East Egg, as I remember. He came only once,
+in white knickerbockers, and had a fight with a bum named Etty in the
+garden. From farther out on the Island came the Cheadles and the O.
+R. P. Schraeders, and the Stonewall Jackson Abrams of Georgia, and the
+Fishguards and the Ripley Snells. Snell was there three days before he
+went to the penitentiary, so drunk out on the gravel drive that
+Mrs. Ulysses Swett’s automobile ran over his right hand. The Dancies
+came, too, and S. B. Whitebait, who was well over sixty, and Maurice
+A. Flink, and the Hammerheads, and Beluga the tobacco importer, and
+Beluga’s girls.
+
+From West Egg came the Poles and the Mulreadys and Cecil Roebuck and
+Cecil Schoen and Gulick the State senator and Newton Orchid, who
+controlled Films Par Excellence, and Eckhaust and Clyde Cohen and Don
+S. Schwartz (the son) and Arthur McCarty, all connected with the
+movies in one way or another. And the Catlips and the Bembergs and G.
+Earl Muldoon, brother to that Muldoon who afterward strangled his
+wife. Da Fontano the promoter came there, and Ed Legros and James B.
+(“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+gamble, and when Ferret wandered into the garden it meant he was
+cleaned out and Associated Traction would have to fluctuate profitably
+next day.
+
+A man named Klipspringer was there so often that he became known as
+“the boarder”—I doubt if he had any other home. Of theatrical people
+there were Gus Waize and Horace O’Donavan and Lester Myer and George
+Duckweed and Francis Bull. Also from New York were the Chromes and the
+Backhyssons and the Dennickers and Russel Betty and the Corrigans and
+the Kellehers and the Dewars and the Scullys and S. W. Belcher and the
+Smirkes and the young Quinns, divorced now, and Henry L. Palmetto, who
+killed himself by jumping in front of a subway train in Times Square.
+
+Benny McClenahan arrived always with four girls. They were never quite
+the same ones in physical person, but they were so identical one with
+another that it inevitably seemed they had been there before. I have
+forgotten their names—Jaqueline, I think, or else Consuela, or Gloria
+or Judy or June, and their last names were either the melodious names
+of flowers and months or the sterner ones of the great American
+capitalists whose cousins, if pressed, they would confess themselves
+to be.
+
+In addition to all these I can remember that Faustina O’Brien came
+there at least once and the Baedeker girls and young Brewer, who had
+his nose shot off in the war, and Mr. Albrucksburger and Miss Haag,
+his fiancée, and Ardita Fitz-Peters and Mr. P. Jewett, once head of
+the American Legion, and Miss Claudia Hip, with a man reputed to be
+her chauffeur, and a prince of something, whom we called Duke, and
+whose name, if I ever knew it, I have forgotten.
+
+All these people came to Gatsby’s house in the summer.
+
+------------------------------------------------------------------------
+
+At nine o’clock, one morning late in July, Gatsby’s gorgeous car
+lurched up the rocky drive to my door and gave out a burst of melody
+from its three-noted horn.
+
+It was the first time he had called on me, though I had gone to two of
+his parties, mounted in his hydroplane, and, at his urgent invitation,
+made frequent use of his beach.
+
+“Good morning, old sport. You’re having lunch with me today and I
+thought we’d ride up together.”
+
+He was balancing himself on the dashboard of his car with that
+resourcefulness of movement that is so peculiarly American—that comes,
+I suppose, with the absence of lifting work in youth and, even more,
+with the formless grace of our nervous, sporadic games. This quality
+was continually breaking through his punctilious manner in the shape
+of restlessness. He was never quite still; there was always a tapping
+foot somewhere or the impatient opening and closing of a hand.
+
+He saw me looking with admiration at his car.
+
+“It’s pretty, isn’t it, old sport?” He jumped off to give me a better
+view. “Haven’t you ever seen it before?”
+
+I’d seen it. Everybody had seen it. It was a rich cream colour, bright
+with nickel, swollen here and there in its monstrous length with
+triumphant hatboxes and supper-boxes and toolboxes, and terraced with
+a labyrinth of windshields that mirrored a dozen suns. Sitting down
+behind many layers of glass in a sort of green leather conservatory,
+we started to town.
+
+I had talked with him perhaps half a dozen times in the past month and
+found, to my disappointment, that he had little to say. So my first
+impression, that he was a person of some undefined consequence, had
+gradually faded and he had become simply the proprietor of an
+elaborate roadhouse next door.
+
+And then came that disconcerting ride. We hadn’t reached West Egg
+village before Gatsby began leaving his elegant sentences unfinished
+and slapping himself indecisively on the knee of his caramel-coloured
+suit.
+
+“Look here, old sport,” he broke out surprisingly, “what’s your
+opinion of me, anyhow?”
+
+A little overwhelmed, I began the generalized evasions which that
+question deserves.
+
+“Well, I’m going to tell you something about my life,” he interrupted.
+“I don’t want you to get a wrong idea of me from all these stories you
+hear.”
+
+So he was aware of the bizarre accusations that flavoured conversation
+in his halls.
+
+“I’ll tell you God’s truth.” His right hand suddenly ordered divine
+retribution to stand by. “I am the son of some wealthy people in the
+Middle West—all dead now. I was brought up in America but educated at
+Oxford, because all my ancestors have been educated there for many
+years. It is a family tradition.”
+
+He looked at me sideways—and I knew why Jordan Baker had believed he
+was lying. He hurried the phrase “educated at Oxford,” or swallowed
+it, or choked on it, as though it had bothered him before. And with
+this doubt, his whole statement fell to pieces, and I wondered if
+there wasn’t something a little sinister about him, after all.
+
+“What part of the Middle West?” I inquired casually.
+
+“San Francisco.”
+
+“I see.”
+
+“My family all died and I came into a good deal of money.”
+
+His voice was solemn, as if the memory of that sudden extinction of a
+clan still haunted him. For a moment I suspected that he was pulling
+my leg, but a glance at him convinced me otherwise.
+
+“After that I lived like a young rajah in all the capitals of
+Europe—Paris, Venice, Rome—collecting jewels, chiefly rubies, hunting
+big game, painting a little, things for myself only, and trying to
+forget something very sad that had happened to me long ago.”
+
+With an effort I managed to restrain my incredulous laughter. The very
+phrases were worn so threadbare that they evoked no image except that
+of a turbaned “character” leaking sawdust at every pore as he pursued
+a tiger through the Bois de Boulogne.
+
+“Then came the war, old sport. It was a great relief, and I tried very
+hard to die, but I seemed to bear an enchanted life. I accepted a
+commission as first lieutenant when it began. In the Argonne Forest I
+took the remains of my machine-gun battalion so far forward that there
+was a half mile gap on either side of us where the infantry couldn’t
+advance. We stayed there two days and two nights, a hundred and thirty
+men with sixteen Lewis guns, and when the infantry came up at last
+they found the insignia of three German divisions among the piles of
+dead. I was promoted to be a major, and every Allied government gave
+me a decoration—even Montenegro, little Montenegro down on the
+Adriatic Sea!”
+
+Little Montenegro! He lifted up the words and nodded at them—with his
+smile. The smile comprehended Montenegro’s troubled history and
+sympathized with the brave struggles of the Montenegrin people. It
+appreciated fully the chain of national circumstances which had
+elicited this tribute from Montenegro’s warm little heart. My
+incredulity was submerged in fascination now; it was like skimming
+hastily through a dozen magazines.
+
+He reached in his pocket, and a piece of metal, slung on a ribbon,
+fell into my palm.
+
+“That’s the one from Montenegro.”
+
+To my astonishment, the thing had an authentic look. “Orderi di
+Danilo,” ran the circular legend, “Montenegro, Nicolas Rex.”
+
+“Turn it.”
+
+“Major Jay Gatsby,” I read, “For Valour Extraordinary.”
+
+“Here’s another thing I always carry. A souvenir of Oxford days. It
+was taken in Trinity Quad—the man on my left is now the Earl of
+Doncaster.”
+
+It was a photograph of half a dozen young men in blazers loafing in an
+archway through which were visible a host of spires. There was Gatsby,
+looking a little, not much, younger—with a cricket bat in his hand.
+
+Then it was all true. I saw the skins of tigers flaming in his palace
+on the Grand Canal; I saw him opening a chest of rubies to ease, with
+their crimson-lighted depths, the gnawings of his broken heart.
+
+“I’m going to make a big request of you today,” he said, pocketing his
+souvenirs with satisfaction, “so I thought you ought to know something
+about me. I didn’t want you to think I was just some nobody. You see,
+I usually find myself among strangers because I drift here and there
+trying to forget the sad things that happened to me.” He hesitated.
+“You’ll hear about it this afternoon.”
+
+“At lunch?”
+
+“No, this afternoon. I happened to find out that you’re taking Miss
+Baker to tea.”
+
+“Do you mean you’re in love with Miss Baker?”
+
+“No, old sport, I’m not. But Miss Baker has kindly consented to speak
+to you about this matter.”
+
+I hadn’t the faintest idea what “this matter” was, but I was more
+annoyed than interested. I hadn’t asked Jordan to tea in order to
+discuss Mr. Jay Gatsby. I was sure the request would be something
+utterly fantastic, and for a moment I was sorry I’d ever set foot upon
+his overpopulated lawn.
+
+He wouldn’t say another word. His correctness grew on him as we neared
+the city. We passed Port Roosevelt, where there was a glimpse of
+red-belted oceangoing ships, and sped along a cobbled slum lined with
+the dark, undeserted saloons of the faded-gilt nineteen-hundreds.
+Then the valley of ashes opened out on both sides of us, and I had a
+glimpse of Mrs. Wilson straining at the garage pump with panting
+vitality as we went by.
+
+With fenders spread like wings we scattered light through half
+Astoria—only half, for as we twisted among the pillars of the elevated
+I heard the familiar “jug-jug-spat!” of a motorcycle, and a frantic
+policeman rode alongside.
+
+“All right, old sport,” called Gatsby. We slowed down. Taking a white
+card from his wallet, he waved it before the man’s eyes.
+
+“Right you are,” agreed the policeman, tipping his cap. “Know you next
+time, Mr. Gatsby. Excuse me!”
+
+“What was that?” I inquired. “The picture of Oxford?”
+
+“I was able to do the commissioner a favour once, and he sends me a
+Christmas card every year.”
+
+Over the great bridge, with the sunlight through the girders making a
+constant flicker upon the moving cars, with the city rising up across
+the river in white heaps and sugar lumps all built with a wish out of
+nonolfactory money. The city seen from the Queensboro Bridge is always
+the city seen for the first time, in its first wild promise of all the
+mystery and the beauty in the world.
+
+A dead man passed us in a hearse heaped with blooms, followed by two
+carriages with drawn blinds, and by more cheerful carriages for
+friends. The friends looked out at us with the tragic eyes and short
+upper lips of southeastern Europe, and I was glad that the sight of
+Gatsby’s splendid car was included in their sombre holiday. As we
+crossed Blackwell’s Island a limousine passed us, driven by a white
+chauffeur, in which sat three modish negroes, two bucks and a girl. I
+laughed aloud as the yolks of their eyeballs rolled toward us in
+haughty rivalry.
+
+“Anything can happen now that we’ve slid over this bridge,” I thought;
+“anything at all …”
+
+Even Gatsby could happen, without any particular wonder.
+
+------------------------------------------------------------------------
+
+Roaring noon. In a well-fanned Forty-second Street cellar I met Gatsby
+for lunch. Blinking away the brightness of the street outside, my eyes
+picked him out obscurely in the anteroom, talking to another man.
+
+“Mr. Carraway, this is my friend Mr. Wolfshiem.”
+
+A small, flat-nosed Jew raised his large head and regarded me with two
+fine growths of hair which luxuriated in either nostril. After a
+moment I discovered his tiny eyes in the half-darkness.
+
+“—So I took one look at him,” said Mr. Wolfshiem, shaking my hand
+earnestly, “and what do you think I did?”
+
+“What?” I inquired politely.
+
+But evidently he was not addressing me, for he dropped my hand and
+covered Gatsby with his expressive nose.
+
+“I handed the money to Katspaugh and I said: ‘All right, Katspaugh,
+don’t pay him a penny till he shuts his mouth.’ He shut it then and
+there.”
+
+Gatsby took an arm of each of us and moved forward into the
+restaurant, whereupon Mr. Wolfshiem swallowed a new sentence he was
+starting and lapsed into a somnambulatory abstraction.
+
+“Highballs?” asked the head waiter.
+
+“This is a nice restaurant here,” said Mr. Wolfshiem, looking at the
+presbyterian nymphs on the ceiling. “But I like across the street
+better!”
+
+“Yes, highballs,” agreed Gatsby, and then to Mr. Wolfshiem: “It’s too
+hot over there.”
+
+“Hot and small—yes,” said Mr. Wolfshiem, “but full of memories.”
+
+“What place is that?” I asked.
+
+“The old Metropole.”
+
+“The old Metropole,” brooded Mr. Wolfshiem gloomily. “Filled with
+faces dead and gone. Filled with friends gone now forever. I can’t
+forget so long as I live the night they shot Rosy Rosenthal there. It
+was six of us at the table, and Rosy had eat and drunk a lot all
+evening. When it was almost morning the waiter came up to him with a
+funny look and says somebody wants to speak to him outside. ‘All
+right,’ says Rosy, and begins to get up, and I pulled him down in his
+chair.
+
+“ ‘Let the bastards come in here if they want you, Rosy, but don’t
+you, so help me, move outside this room.’
+
+“It was four o’clock in the morning then, and if we’d of raised the
+blinds we’d of seen daylight.”
+
+“Did he go?” I asked innocently.
+
+“Sure he went.” Mr. Wolfshiem’s nose flashed at me indignantly. “He
+turned around in the door and says: ‘Don’t let that waiter take away
+my coffee!’ Then he went out on the sidewalk, and they shot him three
+times in his full belly and drove away.”
+
+“Four of them were electrocuted,” I said, remembering.
+
+“Five, with Becker.” His nostrils turned to me in an interested way.
+“I understand you’re looking for a business gonnegtion.”
+
+The juxtaposition of these two remarks was startling. Gatsby answered
+for me:
+
+“Oh, no,” he exclaimed, “this isn’t the man.”
+
+“No?” Mr. Wolfshiem seemed disappointed.
+
+“This is just a friend. I told you we’d talk about that some other
+time.”
+
+“I beg your pardon,” said Mr. Wolfshiem, “I had a wrong man.”
+
+A succulent hash arrived, and Mr. Wolfshiem, forgetting the more
+sentimental atmosphere of the old Metropole, began to eat with
+ferocious delicacy. His eyes, meanwhile, roved very slowly all around
+the room—he completed the arc by turning to inspect the people
+directly behind. I think that, except for my presence, he would have
+taken one short glance beneath our own table.
+
+“Look here, old sport,” said Gatsby, leaning toward me, “I’m afraid I
+made you a little angry this morning in the car.”
+
+There was the smile again, but this time I held out against it.
+
+“I don’t like mysteries,” I answered, “and I don’t understand why you
+won’t come out frankly and tell me what you want. Why has it all got
+to come through Miss Baker?”
+
+“Oh, it’s nothing underhand,” he assured me. “Miss Baker’s a great
+sportswoman, you know, and she’d never do anything that wasn’t all
+right.”
+
+Suddenly he looked at his watch, jumped up, and hurried from the room,
+leaving me with Mr. Wolfshiem at the table.
+
+“He has to telephone,” said Mr. Wolfshiem, following him with his
+eyes. “Fine fellow, isn’t he? Handsome to look at and a perfect
+gentleman.”
+
+“Yes.”
+
+“He’s an Oggsford man.”
+
+“Oh!”
+
+“He went to Oggsford College in England. You know Oggsford College?”
+
+“I’ve heard of it.”
+
+“It’s one of the most famous colleges in the world.”
+
+“Have you known Gatsby for a long time?” I inquired.
+
+“Several years,” he answered in a gratified way. “I made the pleasure
+of his acquaintance just after the war. But I knew I had discovered a
+man of fine breeding after I talked with him an hour. I said to
+myself: ‘There’s the kind of man you’d like to take home and introduce
+to your mother and sister.’ ” He paused. “I see you’re looking at my
+cuff buttons.”
+
+I hadn’t been looking at them, but I did now. They were composed of
+oddly familiar pieces of ivory.
+
+“Finest specimens of human molars,” he informed me.
+
+“Well!” I inspected them. “That’s a very interesting idea.”
+
+“Yeah.” He flipped his sleeves up under his coat. “Yeah, Gatsby’s very
+careful about women. He would never so much as look at a friend’s
+wife.”
+
+When the subject of this instinctive trust returned to the table and
+sat down Mr. Wolfshiem drank his coffee with a jerk and got to his
+feet.
+
+“I have enjoyed my lunch,” he said, “and I’m going to run off from you
+two young men before I outstay my welcome.”
+
+“Don’t hurry Meyer,” said Gatsby, without enthusiasm. Mr. Wolfshiem
+raised his hand in a sort of benediction.
+
+“You’re very polite, but I belong to another generation,” he announced
+solemnly. “You sit here and discuss your sports and your young ladies
+and your—” He supplied an imaginary noun with another wave of his
+hand. “As for me, I am fifty years old, and I won’t impose myself on
+you any longer.”
+
+As he shook hands and turned away his tragic nose was trembling. I
+wondered if I had said anything to offend him.
+
+“He becomes very sentimental sometimes,” explained Gatsby. “This is
+one of his sentimental days. He’s quite a character around New York—a
+denizen of Broadway.”
+
+“Who is he, anyhow, an actor?”
+
+“No.”
+
+“A dentist?”
+
+“Meyer Wolfshiem? No, he’s a gambler.” Gatsby hesitated, then added,
+coolly: “He’s the man who fixed the World’s Series back in 1919.”
+
+“Fixed the World’s Series?” I repeated.
+
+The idea staggered me. I remembered, of course, that the World’s
+Series had been fixed in 1919, but if I had thought of it at all I
+would have thought of it as a thing that merely happened, the end of
+some inevitable chain. It never occurred to me that one man could
+start to play with the faith of fifty million people—with the
+single-mindedness of a burglar blowing a safe.
+
+“How did he happen to do that?” I asked after a minute.
+
+“He just saw the opportunity.”
+
+“Why isn’t he in jail?”
+
+“They can’t get him, old sport. He’s a smart man.”
+
+I insisted on paying the check. As the waiter brought my change I
+caught sight of Tom Buchanan across the crowded room.
+
+“Come along with me for a minute,” I said; “I’ve got to say hello to
+someone.”
+
+When he saw us Tom jumped up and took half a dozen steps in our
+direction.
+
+“Where’ve you been?” he demanded eagerly. “Daisy’s furious because you
+haven’t called up.”
+
+“This is Mr. Gatsby, Mr. Buchanan.”
+
+They shook hands briefly, and a strained, unfamiliar look of
+embarrassment came over Gatsby’s face.
+
+“How’ve you been, anyhow?” demanded Tom of me. “How’d you happen to
+come up this far to eat?”
+
+“I’ve been having lunch with Mr. Gatsby.”
+
+I turned toward Mr. Gatsby, but he was no longer there.
+
+------------------------------------------------------------------------
+
+One October day in nineteen-seventeen—
+
+(said Jordan Baker that afternoon, sitting up very straight on a
+straight chair in the tea-garden at the Plaza Hotel)
+
+—I was walking along from one place to another, half on the sidewalks
+and half on the lawns. I was happier on the lawns because I had on
+shoes from England with rubber knobs on the soles that bit into the
+soft ground. I had on a new plaid skirt also that blew a little in the
+wind, and whenever this happened the red, white, and blue banners in
+front of all the houses stretched out stiff and said tut-tut-tut-tut,
+in a disapproving way.
+
+The largest of the banners and the largest of the lawns belonged to
+Daisy Fay’s house. She was just eighteen, two years older than me, and
+by far the most popular of all the young girls in Louisville. She
+dressed in white, and had a little white roadster, and all day long
+the telephone rang in her house and excited young officers from Camp
+Taylor demanded the privilege of monopolizing her that
+night. “Anyways, for an hour!”
+
+When I came opposite her house that morning her white roadster was
+beside the kerb, and she was sitting in it with a lieutenant I had
+never seen before. They were so engrossed in each other that she
+didn’t see me until I was five feet away.
+
+“Hello, Jordan,” she called unexpectedly. “Please come here.”
+
+I was flattered that she wanted to speak to me, because of all the
+older girls I admired her most. She asked me if I was going to the Red
+Cross to make bandages. I was. Well, then, would I tell them that she
+couldn’t come that day? The officer looked at Daisy while she was
+speaking, in a way that every young girl wants to be looked at
+sometime, and because it seemed romantic to me I have remembered the
+incident ever since. His name was Jay Gatsby, and I didn’t lay eyes on
+him again for over four years—even after I’d met him on Long Island I
+didn’t realize it was the same man.
+
+That was nineteen-seventeen. By the next year I had a few beaux
+myself, and I began to play in tournaments, so I didn’t see Daisy very
+often. She went with a slightly older crowd—when she went with anyone
+at all. Wild rumours were circulating about her—how her mother had
+found her packing her bag one winter night to go to New York and say
+goodbye to a soldier who was going overseas. She was effectually
+prevented, but she wasn’t on speaking terms with her family for
+several weeks. After that she didn’t play around with the soldiers any
+more, but only with a few flat-footed, shortsighted young men in town,
+who couldn’t get into the army at all.
+
+By the next autumn she was gay again, gay as ever. She had a début
+after the armistice, and in February she was presumably engaged to a
+man from New Orleans. In June she married Tom Buchanan of Chicago,
+with more pomp and circumstance than Louisville ever knew before. He
+came down with a hundred people in four private cars, and hired a
+whole floor of the Muhlbach Hotel, and the day before the wedding he
+gave her a string of pearls valued at three hundred and fifty thousand
+dollars.
+
+I was a bridesmaid. I came into her room half an hour before the
+bridal dinner, and found her lying on her bed as lovely as the June
+night in her flowered dress—and as drunk as a monkey. She had a bottle
+of Sauterne in one hand and a letter in the other.
+
+“ ’Gratulate me,” she muttered. “Never had a drink before, but oh how
+I do enjoy it.”
+
+“What’s the matter, Daisy?”
+
+I was scared, I can tell you; I’d never seen a girl like that before.
+
+“Here, dearies.” She groped around in a wastebasket she had with her
+on the bed and pulled out the string of pearls. “Take ’em downstairs
+and give ’em back to whoever they belong to. Tell ’em all Daisy’s
+change’ her mine. Say: ‘Daisy’s change’ her mine!’ ”
+
+She began to cry—she cried and cried. I rushed out and found her
+mother’s maid, and we locked the door and got her into a cold bath.
+She wouldn’t let go of the letter. She took it into the tub with her
+and squeezed it up in a wet ball, and only let me leave it in the
+soap-dish when she saw that it was coming to pieces like snow.
+
+But she didn’t say another word. We gave her spirits of ammonia and
+put ice on her forehead and hooked her back into her dress, and half
+an hour later, when we walked out of the room, the pearls were around
+her neck and the incident was over. Next day at five o’clock she
+married Tom Buchanan without so much as a shiver, and started off on a
+three months’ trip to the South Seas.
+
+I saw them in Santa Barbara when they came back, and I thought I’d
+never seen a girl so mad about her husband. If he left the room for a
+minute she’d look around uneasily, and say: “Where’s Tom gone?” and
+wear the most abstracted expression until she saw him coming in the
+door. She used to sit on the sand with his head in her lap by the
+hour, rubbing her fingers over his eyes and looking at him with
+unfathomable delight. It was touching to see them together—it made you
+laugh in a hushed, fascinated way. That was in August. A week after I
+left Santa Barbara Tom ran into a wagon on the Ventura road one night,
+and ripped a front wheel off his car. The girl who was with him got
+into the papers, too, because her arm was broken—she was one of the
+chambermaids in the Santa Barbara Hotel.
+
+The next April Daisy had her little girl, and they went to France for
+a year. I saw them one spring in Cannes, and later in Deauville, and
+then they came back to Chicago to settle down. Daisy was popular in
+Chicago, as you know. They moved with a fast crowd, all of them young
+and rich and wild, but she came out with an absolutely perfect
+reputation. Perhaps because she doesn’t drink. It’s a great advantage
+not to drink among hard-drinking people. You can hold your tongue and,
+moreover, you can time any little irregularity of your own so that
+everybody else is so blind that they don’t see or care. Perhaps Daisy
+never went in for amour at all—and yet there’s something in that voice
+of hers …
+
+Well, about six weeks ago, she heard the name Gatsby for the first
+time in years. It was when I asked you—do you remember?—if you knew
+Gatsby in West Egg. After you had gone home she came into my room and
+woke me up, and said: “What Gatsby?” and when I described him—I was
+half asleep—she said in the strangest voice that it must be the man
+she used to know. It wasn’t until then that I connected this Gatsby
+with the officer in her white car.
+
+------------------------------------------------------------------------
+
+When Jordan Baker had finished telling all this we had left the Plaza
+for half an hour and were driving in a victoria through Central Park.
+The sun had gone down behind the tall apartments of the movie stars in
+the West Fifties, and the clear voices of children, already gathered
+like crickets on the grass, rose through the hot twilight:
+
+ “I’m the Sheik of Araby. Your love belongs to me. At night when
+ you’re asleep Into your tent I’ll creep—”
+
+“It was a strange coincidence,” I said.
+
+“But it wasn’t a coincidence at all.”
+
+“Why not?”
+
+“Gatsby bought that house so that Daisy would be just across the bay.”
+
+Then it had not been merely the stars to which he had aspired on that
+June night. He came alive to me, delivered suddenly from the womb of
+his purposeless splendour.
+
+“He wants to know,” continued Jordan, “if you’ll invite Daisy to your
+house some afternoon and then let him come over.”
+
+The modesty of the demand shook me. He had waited five years and
+bought a mansion where he dispensed starlight to casual moths—so that
+he could “come over” some afternoon to a stranger’s garden.
+
+“Did I have to know all this before he could ask such a little thing?”
+
+“He’s afraid, he’s waited so long. He thought you might be
+offended. You see, he’s regular tough underneath it all.”
+
+Something worried me.
+
+“Why didn’t he ask you to arrange a meeting?”
+
+“He wants her to see his house,” she explained. “And your house is
+right next door.”
+
+“Oh!”
+
+“I think he half expected her to wander into one of his parties, some
+night,” went on Jordan, “but she never did. Then he began asking
+people casually if they knew her, and I was the first one he found. It
+was that night he sent for me at his dance, and you should have heard
+the elaborate way he worked up to it. Of course, I immediately
+suggested a luncheon in New York—and I thought he’d go mad:
+
+“ ‘I don’t want to do anything out of the way!’ he kept saying. ‘I
+want to see her right next door.’
+
+“When I said you were a particular friend of Tom’s, he started to
+abandon the whole idea. He doesn’t know very much about Tom, though he
+says he’s read a Chicago paper for years just on the chance of
+catching a glimpse of Daisy’s name.”
+
+It was dark now, and as we dipped under a little bridge I put my arm
+around Jordan’s golden shoulder and drew her toward me and asked her
+to dinner. Suddenly I wasn’t thinking of Daisy and Gatsby any more,
+but of this clean, hard, limited person, who dealt in universal
+scepticism, and who leaned back jauntily just within the circle of my
+arm. A phrase began to beat in my ears with a sort of heady
+excitement: “There are only the pursued, the pursuing, the busy, and
+the tired.”
+
+“And Daisy ought to have something in her life,” murmured Jordan to
+me.
+
+“Does she want to see Gatsby?”
+
+“She’s not to know about it. Gatsby doesn’t want her to know. You’re
+just supposed to invite her to tea.”
+
+We passed a barrier of dark trees, and then the façade of Fifty-Ninth
+Street, a block of delicate pale light, beamed down into the park.
+Unlike Gatsby and Tom Buchanan, I had no girl whose disembodied face
+floated along the dark cornices and blinding signs, and so I drew up
+the girl beside me, tightening my arms. Her wan, scornful mouth
+smiled, and so I drew her up again closer, this time to my face.
+
+
+                                  V
+
+When I came home to West Egg that night I was afraid for a moment that
+my house was on fire. Two o’clock and the whole corner of the
+peninsula was blazing with light, which fell unreal on the shrubbery
+and made thin elongating glints upon the roadside wires. Turning a
+corner, I saw that it was Gatsby’s house, lit from tower to cellar.
+
+At first I thought it was another party, a wild rout that had resolved
+itself into “hide-and-go-seek” or “sardines-in-the-box” with all the
+house thrown open to the game. But there wasn’t a sound. Only wind in
+the trees, which blew the wires and made the lights go off and on
+again as if the house had winked into the darkness. As my taxi groaned
+away I saw Gatsby walking toward me across his lawn.
+
+“Your place looks like the World’s Fair,” I said.
+
+“Does it?” He turned his eyes toward it absently. “I have been
+glancing into some of the rooms. Let’s go to Coney Island, old
+sport. In my car.”
+
+“It’s too late.”
+
+“Well, suppose we take a plunge in the swimming pool? I haven’t made
+use of it all summer.”
+
+“I’ve got to go to bed.”
+
+“All right.”
+
+He waited, looking at me with suppressed eagerness.
+
+“I talked with Miss Baker,” I said after a moment. “I’m going to call
+up Daisy tomorrow and invite her over here to tea.”
+
+“Oh, that’s all right,” he said carelessly. “I don’t want to put you
+to any trouble.”
+
+“What day would suit you?”
+
+“What day would suit you?” he corrected me quickly. “I don’t want to
+put you to any trouble, you see.”
+
+“How about the day after tomorrow?”
+
+He considered for a moment. Then, with reluctance: “I want to get the
+grass cut,” he said.
+
+We both looked down at the grass—there was a sharp line where my
+ragged lawn ended and the darker, well-kept expanse of his began. I
+suspected that he meant my grass.
+
+“There’s another little thing,” he said uncertainly, and hesitated.
+
+“Would you rather put it off for a few days?” I asked.
+
+“Oh, it isn’t about that. At least—” He fumbled with a series of
+beginnings. “Why, I thought—why, look here, old sport, you don’t make
+much money, do you?”
+
+“Not very much.”
+
+This seemed to reassure him and he continued more confidently.
+
+“I thought you didn’t, if you’ll pardon my—you see, I carry on a
+little business on the side, a sort of side line, you understand. And
+I thought that if you don’t make very much—You’re selling bonds,
+aren’t you, old sport?”
+
+“Trying to.”
+
+“Well, this would interest you. It wouldn’t take up much of your time
+and you might pick up a nice bit of money. It happens to be a rather
+confidential sort of thing.”
+
+I realize now that under different circumstances that conversation
+might have been one of the crises of my life. But, because the offer
+was obviously and tactlessly for a service to be rendered, I had no
+choice except to cut him off there.
+
+“I’ve got my hands full,” I said. “I’m much obliged but I couldn’t
+take on any more work.”
+
+“You wouldn’t have to do any business with Wolfshiem.” Evidently he
+thought that I was shying away from the “gonnegtion” mentioned at
+lunch, but I assured him he was wrong. He waited a moment longer,
+hoping I’d begin a conversation, but I was too absorbed to be
+responsive, so he went unwillingly home.
+
+The evening had made me lightheaded and happy; I think I walked into a
+deep sleep as I entered my front door. So I don’t know whether or not
+Gatsby went to Coney Island, or for how many hours he “glanced into
+rooms” while his house blazed gaudily on. I called up Daisy from the
+office next morning, and invited her to come to tea.
+
+“Don’t bring Tom,” I warned her.
+
+“What?”
+
+“Don’t bring Tom.”
+
+“Who is ‘Tom’?” she asked innocently.
+
+The day agreed upon was pouring rain. At eleven o’clock a man in a
+raincoat, dragging a lawn-mower, tapped at my front door and said that
+Mr. Gatsby had sent him over to cut my grass. This reminded me that I
+had forgotten to tell my Finn to come back, so I drove into West Egg
+Village to search for her among soggy whitewashed alleys and to buy
+some cups and lemons and flowers.
+
+The flowers were unnecessary, for at two o’clock a greenhouse arrived
+from Gatsby’s, with innumerable receptacles to contain it. An hour
+later the front door opened nervously, and Gatsby in a white flannel
+suit, silver shirt, and gold-coloured tie, hurried in. He was pale,
+and there were dark signs of sleeplessness beneath his eyes.
+
+“Is everything all right?” he asked immediately.
+
+“The grass looks fine, if that’s what you mean.”
+
+“What grass?” he inquired blankly. “Oh, the grass in the yard.” He
+looked out the window at it, but, judging from his expression, I don’t
+believe he saw a thing.
+
+“Looks very good,” he remarked vaguely. “One of the papers said they
+thought the rain would stop about four. I think it was The
+Journal. Have you got everything you need in the shape of—of tea?”
+
+I took him into the pantry, where he looked a little reproachfully at
+the Finn. Together we scrutinized the twelve lemon cakes from the
+delicatessen shop.
+
+“Will they do?” I asked.
+
+“Of course, of course! They’re fine!” and he added hollowly, “… old
+sport.”
+
+The rain cooled about half-past three to a damp mist, through which
+occasional thin drops swam like dew. Gatsby looked with vacant eyes
+through a copy of Clay’s Economics, starting at the Finnish tread that
+shook the kitchen floor, and peering towards the bleared windows from
+time to time as if a series of invisible but alarming happenings were
+taking place outside. Finally he got up and informed me, in an
+uncertain voice, that he was going home.
+
+“Why’s that?”
+
+“Nobody’s coming to tea. It’s too late!” He looked at his watch as if
+there was some pressing demand on his time elsewhere. “I can’t wait
+all day.”
+
+“Don’t be silly; it’s just two minutes to four.”
+
+He sat down miserably, as if I had pushed him, and simultaneously
+there was the sound of a motor turning into my lane. We both jumped
+up, and, a little harrowed myself, I went out into the yard.
+
+Under the dripping bare lilac-trees a large open car was coming up the
+drive. It stopped. Daisy’s face, tipped sideways beneath a
+three-cornered lavender hat, looked out at me with a bright ecstatic
+smile.
+
+“Is this absolutely where you live, my dearest one?”
+
+The exhilarating ripple of her voice was a wild tonic in the rain. I
+had to follow the sound of it for a moment, up and down, with my ear
+alone, before any words came through. A damp streak of hair lay like a
+dash of blue paint across her cheek, and her hand was wet with
+glistening drops as I took it to help her from the car.
+
+“Are you in love with me,” she said low in my ear, “or why did I have
+to come alone?”
+
+“That’s the secret of Castle Rackrent. Tell your chauffeur to go far
+away and spend an hour.”
+
+“Come back in an hour, Ferdie.” Then in a grave murmur: “His name is
+Ferdie.”
+
+“Does the gasoline affect his nose?”
+
+“I don’t think so,” she said innocently. “Why?”
+
+We went in. To my overwhelming surprise the living-room was deserted.
+
+“Well, that’s funny,” I exclaimed.
+
+“What’s funny?”
+
+She turned her head as there was a light dignified knocking at the
+front door. I went out and opened it. Gatsby, pale as death, with his
+hands plunged like weights in his coat pockets, was standing in a
+puddle of water glaring tragically into my eyes.
+
+With his hands still in his coat pockets he stalked by me into the
+hall, turned sharply as if he were on a wire, and disappeared into the
+living-room. It wasn’t a bit funny. Aware of the loud beating of my
+own heart I pulled the door to against the increasing rain.
+
+For half a minute there wasn’t a sound. Then from the living-room I
+heard a sort of choking murmur and part of a laugh, followed by
+Daisy’s voice on a clear artificial note:
+
+“I certainly am awfully glad to see you again.”
+
+A pause; it endured horribly. I had nothing to do in the hall, so I
+went into the room.
+
+Gatsby, his hands still in his pockets, was reclining against the
+mantelpiece in a strained counterfeit of perfect ease, even of
+boredom. His head leaned back so far that it rested against the face
+of a defunct mantelpiece clock, and from this position his distraught
+eyes stared down at Daisy, who was sitting, frightened but graceful,
+on the edge of a stiff chair.
+
+“We’ve met before,” muttered Gatsby. His eyes glanced momentarily at
+me, and his lips parted with an abortive attempt at a laugh. Luckily
+the clock took this moment to tilt dangerously at the pressure of his
+head, whereupon he turned and caught it with trembling fingers, and
+set it back in place. Then he sat down, rigidly, his elbow on the arm
+of the sofa and his chin in his hand.
+
+“I’m sorry about the clock,” he said.
+
+My own face had now assumed a deep tropical burn. I couldn’t muster up
+a single commonplace out of the thousand in my head.
+
+“It’s an old clock,” I told them idiotically.
+
+I think we all believed for a moment that it had smashed in pieces on
+the floor.
+
+“We haven’t met for many years,” said Daisy, her voice as
+matter-of-fact as it could ever be.
+
+“Five years next November.”
+
+The automatic quality of Gatsby’s answer set us all back at least
+another minute. I had them both on their feet with the desperate
+suggestion that they help me make tea in the kitchen when the demoniac
+Finn brought it in on a tray.
+
+Amid the welcome confusion of cups and cakes a certain physical
+decency established itself. Gatsby got himself into a shadow and,
+while Daisy and I talked, looked conscientiously from one to the other
+of us with tense, unhappy eyes. However, as calmness wasn’t an end in
+itself, I made an excuse at the first possible moment, and got to my
+feet.
+
+“Where are you going?” demanded Gatsby in immediate alarm.
+
+“I’ll be back.”
+
+“I’ve got to speak to you about something before you go.”
+
+He followed me wildly into the kitchen, closed the door, and
+whispered: “Oh, God!” in a miserable way.
+
+“What’s the matter?”
+
+“This is a terrible mistake,” he said, shaking his head from side to
+side, “a terrible, terrible mistake.”
+
+“You’re just embarrassed, that’s all,” and luckily I added: “Daisy’s
+embarrassed too.”
+
+“She’s embarrassed?” he repeated incredulously.
+
+“Just as much as you are.”
+
+“Don’t talk so loud.”
+
+“You’re acting like a little boy,” I broke out impatiently. “Not only
+that, but you’re rude. Daisy’s sitting in there all alone.”
+
+He raised his hand to stop my words, looked at me with unforgettable
+reproach, and, opening the door cautiously, went back into the other
+room.
+
+I walked out the back way—just as Gatsby had when he had made his
+nervous circuit of the house half an hour before—and ran for a huge
+black knotted tree, whose massed leaves made a fabric against the
+rain. Once more it was pouring, and my irregular lawn, well-shaved by
+Gatsby’s gardener, abounded in small muddy swamps and prehistoric
+marshes. There was nothing to look at from under the tree except
+Gatsby’s enormous house, so I stared at it, like Kant at his church
+steeple, for half an hour. A brewer had built it early in the “period”
+craze, a decade before, and there was a story that he’d agreed to pay
+five years’ taxes on all the neighbouring cottages if the owners would
+have their roofs thatched with straw. Perhaps their refusal took the
+heart out of his plan to Found a Family—he went into an immediate
+decline. His children sold his house with the black wreath still on
+the door. Americans, while willing, even eager, to be serfs, have
+always been obstinate about being peasantry.
+
+After half an hour, the sun shone again, and the grocer’s automobile
+rounded Gatsby’s drive with the raw material for his servants’
+dinner—I felt sure he wouldn’t eat a spoonful. A maid began opening
+the upper windows of his house, appeared momentarily in each, and,
+leaning from the large central bay, spat meditatively into the
+garden. It was time I went back. While the rain continued it had
+seemed like the murmur of their voices, rising and swelling a little
+now and then with gusts of emotion. But in the new silence I felt that
+silence had fallen within the house too.
+
+I went in—after making every possible noise in the kitchen, short of
+pushing over the stove—but I don’t believe they heard a sound. They
+were sitting at either end of the couch, looking at each other as if
+some question had been asked, or was in the air, and every vestige of
+embarrassment was gone. Daisy’s face was smeared with tears, and when
+I came in she jumped up and began wiping at it with her handkerchief
+before a mirror. But there was a change in Gatsby that was simply
+confounding. He literally glowed; without a word or a gesture of
+exultation a new well-being radiated from him and filled the little
+room.
+
+“Oh, hello, old sport,” he said, as if he hadn’t seen me for years. I
+thought for a moment he was going to shake hands.
+
+“It’s stopped raining.”
+
+“Has it?” When he realized what I was talking about, that there were
+twinkle-bells of sunshine in the room, he smiled like a weather man,
+like an ecstatic patron of recurrent light, and repeated the news to
+Daisy. “What do you think of that? It’s stopped raining.”
+
+“I’m glad, Jay.” Her throat, full of aching, grieving beauty, told
+only of her unexpected joy.
+
+“I want you and Daisy to come over to my house,” he said, “I’d like to
+show her around.”
+
+“You’re sure you want me to come?”
+
+“Absolutely, old sport.”
+
+Daisy went upstairs to wash her face—too late I thought with
+humiliation of my towels—while Gatsby and I waited on the lawn.
+
+“My house looks well, doesn’t it?” he demanded. “See how the whole
+front of it catches the light.”
+
+I agreed that it was splendid.
+
+“Yes.” His eyes went over it, every arched door and square tower. “It
+took me just three years to earn the money that bought it.”
+
+“I thought you inherited your money.”
+
+“I did, old sport,” he said automatically, “but I lost most of it in
+the big panic—the panic of the war.”
+
+I think he hardly knew what he was saying, for when I asked him what
+business he was in he answered: “That’s my affair,” before he realized
+that it wasn’t an appropriate reply.
+
+“Oh, I’ve been in several things,” he corrected himself. “I was in the
+drug business and then I was in the oil business. But I’m not in
+either one now.” He looked at me with more attention. “Do you mean
+you’ve been thinking over what I proposed the other night?”
+
+Before I could answer, Daisy came out of the house and two rows of
+brass buttons on her dress gleamed in the sunlight.
+
+“That huge place there?” she cried pointing.
+
+“Do you like it?”
+
+“I love it, but I don’t see how you live there all alone.”
+
+“I keep it always full of interesting people, night and day. People
+who do interesting things. Celebrated people.”
+
+Instead of taking the shortcut along the Sound we went down to the
+road and entered by the big postern. With enchanting murmurs Daisy
+admired this aspect or that of the feudal silhouette against the sky,
+admired the gardens, the sparkling odour of jonquils and the frothy
+odour of hawthorn and plum blossoms and the pale gold odour of
+kiss-me-at-the-gate. It was strange to reach the marble steps and find
+no stir of bright dresses in and out the door, and hear no sound but
+bird voices in the trees.
+
+And inside, as we wandered through Marie Antoinette music-rooms and
+Restoration Salons, I felt that there were guests concealed behind
+every couch and table, under orders to be breathlessly silent until we
+had passed through. As Gatsby closed the door of “the Merton College
+Library” I could have sworn I heard the owl-eyed man break into
+ghostly laughter.
+
+We went upstairs, through period bedrooms swathed in rose and lavender
+silk and vivid with new flowers, through dressing-rooms and poolrooms,
+and bathrooms with sunken baths—intruding into one chamber where a
+dishevelled man in pyjamas was doing liver exercises on the floor. It
+was Mr. Klipspringer, the “boarder.” I had seen him wandering hungrily
+about the beach that morning. Finally we came to Gatsby’s own
+apartment, a bedroom and a bath, and an Adam’s study, where we sat
+down and drank a glass of some Chartreuse he took from a cupboard in
+the wall.
+
+He hadn’t once ceased looking at Daisy, and I think he revalued
+everything in his house according to the measure of response it drew
+from her well-loved eyes. Sometimes too, he stared around at his
+possessions in a dazed way, as though in her actual and astounding
+presence none of it was any longer real. Once he nearly toppled down a
+flight of stairs.
+
+His bedroom was the simplest room of all—except where the dresser was
+garnished with a toilet set of pure dull gold. Daisy took the brush
+with delight, and smoothed her hair, whereupon Gatsby sat down and
+shaded his eyes and began to laugh.
+
+“It’s the funniest thing, old sport,” he said hilariously. “I
+can’t—When I try to—”
+
+He had passed visibly through two states and was entering upon a
+third. After his embarrassment and his unreasoning joy he was consumed
+with wonder at her presence. He had been full of the idea so long,
+dreamed it right through to the end, waited with his teeth set, so to
+speak, at an inconceivable pitch of intensity. Now, in the reaction,
+he was running down like an over-wound clock.
+
+Recovering himself in a minute he opened for us two hulking patent
+cabinets which held his massed suits and dressing-gowns and ties, and
+his shirts, piled like bricks in stacks a dozen high.
+
+“I’ve got a man in England who buys me clothes. He sends over a
+selection of things at the beginning of each season, spring and fall.”
+
+He took out a pile of shirts and began throwing them, one by one,
+before us, shirts of sheer linen and thick silk and fine flannel,
+which lost their folds as they fell and covered the table in
+many-coloured disarray. While we admired he brought more and the soft
+rich heap mounted higher—shirts with stripes and scrolls and plaids in
+coral and apple-green and lavender and faint orange, with monograms of
+indian blue. Suddenly, with a strained sound, Daisy bent her head into
+the shirts and began to cry stormily.
+
+“They’re such beautiful shirts,” she sobbed, her voice muffled in the
+thick folds. “It makes me sad because I’ve never seen such—such
+beautiful shirts before.”
+
+------------------------------------------------------------------------
+
+After the house, we were to see the grounds and the swimming pool, and
+the hydroplane, and the midsummer flowers—but outside Gatsby’s window
+it began to rain again, so we stood in a row looking at the corrugated
+surface of the Sound.
+
+“If it wasn’t for the mist we could see your home across the bay,”
+said Gatsby. “You always have a green light that burns all night at
+the end of your dock.”
+
+Daisy put her arm through his abruptly, but he seemed absorbed in what
+he had just said. Possibly it had occurred to him that the colossal
+significance of that light had now vanished forever. Compared to the
+great distance that had separated him from Daisy it had seemed very
+near to her, almost touching her. It had seemed as close as a star to
+the moon. Now it was again a green light on a dock. His count of
+enchanted objects had diminished by one.
+
+I began to walk about the room, examining various indefinite objects
+in the half darkness. A large photograph of an elderly man in yachting
+costume attracted me, hung on the wall over his desk.
+
+“Who’s this?”
+
+“That? That’s Mr. Dan Cody, old sport.”
+
+The name sounded faintly familiar.
+
+“He’s dead now. He used to be my best friend years ago.”
+
+There was a small picture of Gatsby, also in yachting costume, on the
+bureau—Gatsby with his head thrown back defiantly—taken apparently
+when he was about eighteen.
+
+“I adore it,” exclaimed Daisy. “The pompadour! You never told me you
+had a pompadour—or a yacht.”
+
+“Look at this,” said Gatsby quickly. “Here’s a lot of clippings—about
+you.”
+
+They stood side by side examining it. I was going to ask to see the
+rubies when the phone rang, and Gatsby took up the receiver.
+
+“Yes … Well, I can’t talk now … I can’t talk now, old sport … I said a
+small town … He must know what a small town is … Well, he’s no use to
+us if Detroit is his idea of a small town …”
+
+He rang off.
+
+“Come here quick!” cried Daisy at the window.
+
+The rain was still falling, but the darkness had parted in the west,
+and there was a pink and golden billow of foamy clouds above the sea.
+
+“Look at that,” she whispered, and then after a moment: “I’d like to
+just get one of those pink clouds and put you in it and push you
+around.”
+
+I tried to go then, but they wouldn’t hear of it; perhaps my presence
+made them feel more satisfactorily alone.
+
+“I know what we’ll do,” said Gatsby, “we’ll have Klipspringer play the
+piano.”
+
+He went out of the room calling “Ewing!” and returned in a few minutes
+accompanied by an embarrassed, slightly worn young man, with
+shell-rimmed glasses and scanty blond hair. He was now decently
+clothed in a “sport shirt,” open at the neck, sneakers, and duck
+trousers of a nebulous hue.
+
+“Did we interrupt your exercise?” inquired Daisy politely.
+
+“I was asleep,” cried Mr. Klipspringer, in a spasm of embarrassment.
+“That is, I’d been asleep. Then I got up …”
+
+“Klipspringer plays the piano,” said Gatsby, cutting him off. “Don’t
+you, Ewing, old sport?”
+
+“I don’t play well. I don’t—hardly play at all. I’m all out of prac—”
+
+“We’ll go downstairs,” interrupted Gatsby. He flipped a switch. The
+grey windows disappeared as the house glowed full of light.
+
+In the music-room Gatsby turned on a solitary lamp beside the piano.
+He lit Daisy’s cigarette from a trembling match, and sat down with her
+on a couch far across the room, where there was no light save what the
+gleaming floor bounced in from the hall.
+
+When Klipspringer had played “The Love Nest” he turned around on the
+bench and searched unhappily for Gatsby in the gloom.
+
+“I’m all out of practice, you see. I told you I couldn’t play. I’m all
+out of prac—”
+
+“Don’t talk so much, old sport,” commanded Gatsby. “Play!”
+
+ “In the morning, In the evening, Ain’t we got fun—”
+
+Outside the wind was loud and there was a faint flow of thunder along
+the Sound. All the lights were going on in West Egg now; the electric
+trains, men-carrying, were plunging home through the rain from New
+York. It was the hour of a profound human change, and excitement was
+generating on the air.
+
+ “One thing’s sure and nothing’s surer The rich get richer and the
+ poor get—children. In the meantime, In between time—”
+
+As I went over to say goodbye I saw that the expression of
+bewilderment had come back into Gatsby’s face, as though a faint doubt
+had occurred to him as to the quality of his present happiness. Almost
+five years! There must have been moments even that afternoon when
+Daisy tumbled short of his dreams—not through her own fault, but
+because of the colossal vitality of his illusion. It had gone beyond
+her, beyond everything. He had thrown himself into it with a creative
+passion, adding to it all the time, decking it out with every bright
+feather that drifted his way. No amount of fire or freshness can
+challenge what a man can store up in his ghostly heart.
+
+As I watched him he adjusted himself a little, visibly. His hand took
+hold of hers, and as she said something low in his ear he turned
+toward her with a rush of emotion. I think that voice held him most,
+with its fluctuating, feverish warmth, because it couldn’t be
+over-dreamed—that voice was a deathless song.
+
+They had forgotten me, but Daisy glanced up and held out her hand;
+Gatsby didn’t know me now at all. I looked once more at them and they
+looked back at me, remotely, possessed by intense life. Then I went
+out of the room and down the marble steps into the rain, leaving them
+there together.
+
+
+                                  VI
+
+About this time an ambitious young reporter from New York arrived one
+morning at Gatsby’s door and asked him if he had anything to say.
+
+“Anything to say about what?” inquired Gatsby politely.
+
+“Why—any statement to give out.”
+
+It transpired after a confused five minutes that the man had heard
+Gatsby’s name around his office in a connection which he either
+wouldn’t reveal or didn’t fully understand. This was his day off and
+with laudable initiative he had hurried out “to see.”
+
+It was a random shot, and yet the reporter’s instinct was right.
+Gatsby’s notoriety, spread about by the hundreds who had accepted his
+hospitality and so become authorities upon his past, had increased all
+summer until he fell just short of being news. Contemporary legends
+such as the “underground pipeline to Canada” attached themselves to
+him, and there was one persistent story that he didn’t live in a house
+at all, but in a boat that looked like a house and was moved secretly
+up and down the Long Island shore. Just why these inventions were a
+source of satisfaction to James Gatz of North Dakota, isn’t easy to
+say.
+
+James Gatz—that was really, or at least legally, his name. He had
+changed it at the age of seventeen and at the specific moment that
+witnessed the beginning of his career—when he saw Dan Cody’s yacht
+drop anchor over the most insidious flat on Lake Superior. It was
+James Gatz who had been loafing along the beach that afternoon in a
+torn green jersey and a pair of canvas pants, but it was already Jay
+Gatsby who borrowed a rowboat, pulled out to the Tuolomee, and
+informed Cody that a wind might catch him and break him up in half an
+hour.
+
+I suppose he’d had the name ready for a long time, even then. His
+parents were shiftless and unsuccessful farm people—his imagination
+had never really accepted them as his parents at all. The truth was
+that Jay Gatsby of West Egg, Long Island, sprang from his Platonic
+conception of himself. He was a son of God—a phrase which, if it means
+anything, means just that—and he must be about His Father’s business,
+the service of a vast, vulgar, and meretricious beauty. So he invented
+just the sort of Jay Gatsby that a seventeen-year-old boy would be
+likely to invent, and to this conception he was faithful to the end.
+
+For over a year he had been beating his way along the south shore of
+Lake Superior as a clam-digger and a salmon-fisher or in any other
+capacity that brought him food and bed. His brown, hardening body
+lived naturally through the half-fierce, half-lazy work of the bracing
+days. He knew women early, and since they spoiled him he became
+contemptuous of them, of young virgins because they were ignorant, of
+the others because they were hysterical about things which in his
+overwhelming self-absorption he took for granted.
+
+But his heart was in a constant, turbulent riot. The most grotesque
+and fantastic conceits haunted him in his bed at night. A universe of
+ineffable gaudiness spun itself out in his brain while the clock
+ticked on the washstand and the moon soaked with wet light his tangled
+clothes upon the floor. Each night he added to the pattern of his
+fancies until drowsiness closed down upon some vivid scene with an
+oblivious embrace. For a while these reveries provided an outlet for
+his imagination; they were a satisfactory hint of the unreality of
+reality, a promise that the rock of the world was founded securely on
+a fairy’s wing.
+
+An instinct toward his future glory had led him, some months before,
+to the small Lutheran College of St. Olaf’s in southern Minnesota. He
+stayed there two weeks, dismayed at its ferocious indifference to the
+drums of his destiny, to destiny itself, and despising the janitor’s
+work with which he was to pay his way through. Then he drifted back to
+Lake Superior, and he was still searching for something to do on the
+day that Dan Cody’s yacht dropped anchor in the shallows alongshore.
+
+Cody was fifty years old then, a product of the Nevada silver fields,
+of the Yukon, of every rush for metal since seventy-five. The
+transactions in Montana copper that made him many times a millionaire
+found him physically robust but on the verge of soft-mindedness, and,
+suspecting this, an infinite number of women tried to separate him
+from his money. The none too savoury ramifications by which Ella Kaye,
+the newspaper woman, played Madame de Maintenon to his weakness and
+sent him to sea in a yacht, were common property of the turgid
+journalism in 1902. He had been coasting along all too hospitable
+shores for five years when he turned up as James Gatz’s destiny in
+Little Girl Bay.
+
+To young Gatz, resting on his oars and looking up at the railed deck,
+that yacht represented all the beauty and glamour in the world. I
+suppose he smiled at Cody—he had probably discovered that people liked
+him when he smiled. At any rate Cody asked him a few questions (one of
+them elicited the brand new name) and found that he was quick and
+extravagantly ambitious. A few days later he took him to Duluth and
+bought him a blue coat, six pairs of white duck trousers, and a
+yachting cap. And when the Tuolomee left for the West Indies and the
+Barbary Coast, Gatsby left too.
+
+He was employed in a vague personal capacity—while he remained with
+Cody he was in turn steward, mate, skipper, secretary, and even
+jailor, for Dan Cody sober knew what lavish doings Dan Cody drunk
+might soon be about, and he provided for such contingencies by
+reposing more and more trust in Gatsby. The arrangement lasted five
+years, during which the boat went three times around the Continent.
+It might have lasted indefinitely except for the fact that Ella Kaye
+came on board one night in Boston and a week later Dan Cody
+inhospitably died.
+
+I remember the portrait of him up in Gatsby’s bedroom, a grey, florid
+man with a hard, empty face—the pioneer debauchee, who during one
+phase of American life brought back to the Eastern seaboard the savage
+violence of the frontier brothel and saloon. It was indirectly due to
+Cody that Gatsby drank so little. Sometimes in the course of gay
+parties women used to rub champagne into his hair; for himself he
+formed the habit of letting liquor alone.
+
+And it was from Cody that he inherited money—a legacy of twenty-five
+thousand dollars. He didn’t get it. He never understood the legal
+device that was used against him, but what remained of the millions
+went intact to Ella Kaye. He was left with his singularly appropriate
+education; the vague contour of Jay Gatsby had filled out to the
+substantiality of a man.
+
+------------------------------------------------------------------------
+
+He told me all this very much later, but I’ve put it down here with
+the idea of exploding those first wild rumours about his antecedents,
+which weren’t even faintly true. Moreover he told it to me at a time
+of confusion, when I had reached the point of believing everything and
+nothing about him. So I take advantage of this short halt, while
+Gatsby, so to speak, caught his breath, to clear this set of
+misconceptions away.
+
+It was a halt, too, in my association with his affairs. For several
+weeks I didn’t see him or hear his voice on the phone—mostly I was in
+New York, trotting around with Jordan and trying to ingratiate myself
+with her senile aunt—but finally I went over to his house one Sunday
+afternoon. I hadn’t been there two minutes when somebody brought Tom
+Buchanan in for a drink. I was startled, naturally, but the really
+surprising thing was that it hadn’t happened before.
+
+They were a party of three on horseback—Tom and a man named Sloane and
+a pretty woman in a brown riding-habit, who had been there previously.
+
+“I’m delighted to see you,” said Gatsby, standing on his porch. “I’m
+delighted that you dropped in.”
+
+As though they cared!
+
+“Sit right down. Have a cigarette or a cigar.” He walked around the
+room quickly, ringing bells. “I’ll have something to drink for you in
+just a minute.”
+
+He was profoundly affected by the fact that Tom was there. But he
+would be uneasy anyhow until he had given them something, realizing in
+a vague way that that was all they came for. Mr. Sloane wanted
+nothing. A lemonade? No, thanks. A little champagne? Nothing at all,
+thanks … I’m sorry—
+
+“Did you have a nice ride?”
+
+“Very good roads around here.”
+
+“I suppose the automobiles—”
+
+“Yeah.”
+
+Moved by an irresistible impulse, Gatsby turned to Tom, who had
+accepted the introduction as a stranger.
+
+“I believe we’ve met somewhere before, Mr. Buchanan.”
+
+“Oh, yes,” said Tom, gruffly polite, but obviously not remembering.
+“So we did. I remember very well.”
+
+“About two weeks ago.”
+
+“That’s right. You were with Nick here.”
+
+“I know your wife,” continued Gatsby, almost aggressively.
+
+“That so?”
+
+Tom turned to me.
+
+“You live near here, Nick?”
+
+“Next door.”
+
+“That so?”
+
+Mr. Sloane didn’t enter into the conversation, but lounged back
+haughtily in his chair; the woman said nothing either—until
+unexpectedly, after two highballs, she became cordial.
+
+“We’ll all come over to your next party, Mr. Gatsby,” she suggested.
+“What do you say?”
+
+“Certainly; I’d be delighted to have you.”
+
+“Be ver’ nice,” said Mr. Sloane, without gratitude. “Well—think ought
+to be starting home.”
+
+“Please don’t hurry,” Gatsby urged them. He had control of himself
+now, and he wanted to see more of Tom. “Why don’t you—why don’t you
+stay for supper? I wouldn’t be surprised if some other people dropped
+in from New York.”
+
+“You come to supper with me,” said the lady enthusiastically. “Both of
+you.”
+
+This included me. Mr. Sloane got to his feet.
+
+“Come along,” he said—but to her only.
+
+“I mean it,” she insisted. “I’d love to have you. Lots of room.”
+
+Gatsby looked at me questioningly. He wanted to go and he didn’t see
+that Mr. Sloane had determined he shouldn’t.
+
+“I’m afraid I won’t be able to,” I said.
+
+“Well, you come,” she urged, concentrating on Gatsby.
+
+Mr. Sloane murmured something close to her ear.
+
+“We won’t be late if we start now,” she insisted aloud.
+
+“I haven’t got a horse,” said Gatsby. “I used to ride in the army, but
+I’ve never bought a horse. I’ll have to follow you in my car. Excuse
+me for just a minute.”
+
+The rest of us walked out on the porch, where Sloane and the lady
+began an impassioned conversation aside.
+
+“My God, I believe the man’s coming,” said Tom. “Doesn’t he know she
+doesn’t want him?”
+
+“She says she does want him.”
+
+“She has a big dinner party and he won’t know a soul there.” He
+frowned. “I wonder where in the devil he met Daisy. By God, I may be
+old-fashioned in my ideas, but women run around too much these days to
+suit me. They meet all kinds of crazy fish.”
+
+Suddenly Mr. Sloane and the lady walked down the steps and mounted
+their horses.
+
+“Come on,” said Mr. Sloane to Tom, “we’re late. We’ve got to go.”  And
+then to me: “Tell him we couldn’t wait, will you?”
+
+Tom and I shook hands, the rest of us exchanged a cool nod, and they
+trotted quickly down the drive, disappearing under the August foliage
+just as Gatsby, with hat and light overcoat in hand, came out the
+front door.
+
+Tom was evidently perturbed at Daisy’s running around alone, for on
+the following Saturday night he came with her to Gatsby’s
+party. Perhaps his presence gave the evening its peculiar quality of
+oppressiveness—it stands out in my memory from Gatsby’s other parties
+that summer. There were the same people, or at least the same sort of
+people, the same profusion of champagne, the same many-coloured,
+many-keyed commotion, but I felt an unpleasantness in the air, a
+pervading harshness that hadn’t been there before. Or perhaps I had
+merely grown used to it, grown to accept West Egg as a world complete
+in itself, with its own standards and its own great figures, second to
+nothing because it had no consciousness of being so, and now I was
+looking at it again, through Daisy’s eyes. It is invariably saddening
+to look through new eyes at things upon which you have expended your
+own powers of adjustment.
+
+They arrived at twilight, and, as we strolled out among the sparkling
+hundreds, Daisy’s voice was playing murmurous tricks in her throat.
+
+“These things excite me so,” she whispered. “If you want to kiss me
+any time during the evening, Nick, just let me know and I’ll be glad
+to arrange it for you. Just mention my name. Or present a green card.
+I’m giving out green—”
+
+“Look around,” suggested Gatsby.
+
+“I’m looking around. I’m having a marvellous—”
+
+“You must see the faces of many people you’ve heard about.”
+
+Tom’s arrogant eyes roamed the crowd.
+
+“We don’t go around very much,” he said; “in fact, I was just thinking
+I don’t know a soul here.”
+
+“Perhaps you know that lady.” Gatsby indicated a gorgeous, scarcely
+human orchid of a woman who sat in state under a white-plum tree. Tom
+and Daisy stared, with that peculiarly unreal feeling that accompanies
+the recognition of a hitherto ghostly celebrity of the movies.
+
+“She’s lovely,” said Daisy.
+
+“The man bending over her is her director.”
+
+He took them ceremoniously from group to group:
+
+“Mrs. Buchanan … and Mr. Buchanan—” After an instant’s hesitation he
+added: “the polo player.”
+
+“Oh no,” objected Tom quickly, “not me.”
+
+But evidently the sound of it pleased Gatsby for Tom remained “the
+polo player” for the rest of the evening.
+
+“I’ve never met so many celebrities,” Daisy exclaimed. “I liked that
+man—what was his name?—with the sort of blue nose.”
+
+Gatsby identified him, adding that he was a small producer.
+
+“Well, I liked him anyhow.”
+
+“I’d a little rather not be the polo player,” said Tom pleasantly,
+“I’d rather look at all these famous people in—in oblivion.”
+
+Daisy and Gatsby danced. I remember being surprised by his graceful,
+conservative foxtrot—I had never seen him dance before. Then they
+sauntered over to my house and sat on the steps for half an hour,
+while at her request I remained watchfully in the garden. “In case
+there’s a fire or a flood,” she explained, “or any act of God.”
+
+Tom appeared from his oblivion as we were sitting down to supper
+together. “Do you mind if I eat with some people over here?” he
+said. “A fellow’s getting off some funny stuff.”
+
+“Go ahead,” answered Daisy genially, “and if you want to take down any
+addresses here’s my little gold pencil.” … She looked around after a
+moment and told me the girl was “common but pretty,” and I knew that
+except for the half-hour she’d been alone with Gatsby she wasn’t
+having a good time.
+
+We were at a particularly tipsy table. That was my fault—Gatsby had
+been called to the phone, and I’d enjoyed these same people only two
+weeks before. But what had amused me then turned septic on the air
+now.
+
+“How do you feel, Miss Baedeker?”
+
+The girl addressed was trying, unsuccessfully, to slump against my
+shoulder. At this inquiry she sat up and opened her eyes.
+
+“Wha’?”
+
+A massive and lethargic woman, who had been urging Daisy to play golf
+with her at the local club tomorrow, spoke in Miss Baedeker’s defence:
+
+“Oh, she’s all right now. When she’s had five or six cocktails she
+always starts screaming like that. I tell her she ought to leave it
+alone.”
+
+“I do leave it alone,” affirmed the accused hollowly.
+
+“We heard you yelling, so I said to Doc Civet here: ‘There’s somebody
+that needs your help, Doc.’ ”
+
+“She’s much obliged, I’m sure,” said another friend, without
+gratitude, “but you got her dress all wet when you stuck her head in
+the pool.”
+
+“Anything I hate is to get my head stuck in a pool,” mumbled Miss
+Baedeker. “They almost drowned me once over in New Jersey.”
+
+“Then you ought to leave it alone,” countered Doctor Civet.
+
+“Speak for yourself!” cried Miss Baedeker violently. “Your hand
+shakes. I wouldn’t let you operate on me!”
+
+It was like that. Almost the last thing I remember was standing with
+Daisy and watching the moving-picture director and his Star. They were
+still under the white-plum tree and their faces were touching except
+for a pale, thin ray of moonlight between. It occurred to me that he
+had been very slowly bending toward her all evening to attain this
+proximity, and even while I watched I saw him stoop one ultimate
+degree and kiss at her cheek.
+
+“I like her,” said Daisy, “I think she’s lovely.”
+
+But the rest offended her—and inarguably because it wasn’t a gesture
+but an emotion. She was appalled by West Egg, this unprecedented
+“place” that Broadway had begotten upon a Long Island fishing
+village—appalled by its raw vigour that chafed under the old
+euphemisms and by the too obtrusive fate that herded its inhabitants
+along a shortcut from nothing to nothing. She saw something awful in
+the very simplicity she failed to understand.
+
+I sat on the front steps with them while they waited for their car.
+It was dark here in front; only the bright door sent ten square feet
+of light volleying out into the soft black morning. Sometimes a shadow
+moved against a dressing-room blind above, gave way to another shadow,
+an indefinite procession of shadows, who rouged and powdered in an
+invisible glass.
+
+“Who is this Gatsby anyhow?” demanded Tom suddenly. “Some big
+bootlegger?”
+
+“Where’d you hear that?” I inquired.
+
+“I didn’t hear it. I imagined it. A lot of these newly rich people are
+just big bootleggers, you know.”
+
+“Not Gatsby,” I said shortly.
+
+He was silent for a moment. The pebbles of the drive crunched under
+his feet.
+
+“Well, he certainly must have strained himself to get this menagerie
+together.”
+
+A breeze stirred the grey haze of Daisy’s fur collar.
+
+“At least they are more interesting than the people we know,” she said
+with an effort.
+
+“You didn’t look so interested.”
+
+“Well, I was.”
+
+Tom laughed and turned to me.
+
+“Did you notice Daisy’s face when that girl asked her to put her under
+a cold shower?”
+
+Daisy began to sing with the music in a husky, rhythmic whisper,
+bringing out a meaning in each word that it had never had before and
+would never have again. When the melody rose her voice broke up
+sweetly, following it, in a way contralto voices have, and each change
+tipped out a little of her warm human magic upon the air.
+
+“Lots of people come who haven’t been invited,” she said
+suddenly. “That girl hadn’t been invited. They simply force their way
+in and he’s too polite to object.”
+
+“I’d like to know who he is and what he does,” insisted Tom. “And I
+think I’ll make a point of finding out.”
+
+“I can tell you right now,” she answered. “He owned some drugstores, a
+lot of drugstores. He built them up himself.”
+
+The dilatory limousine came rolling up the drive.
+
+“Good night, Nick,” said Daisy.
+
+Her glance left me and sought the lighted top of the steps, where
+“Three O’Clock in the Morning,” a neat, sad little waltz of that year,
+was drifting out the open door. After all, in the very casualness of
+Gatsby’s party there were romantic possibilities totally absent from
+her world. What was it up there in the song that seemed to be calling
+her back inside? What would happen now in the dim, incalculable hours?
+Perhaps some unbelievable guest would arrive, a person infinitely rare
+and to be marvelled at, some authentically radiant young girl who with
+one fresh glance at Gatsby, one moment of magical encounter, would
+blot out those five years of unwavering devotion.
+
+I stayed late that night. Gatsby asked me to wait until he was free,
+and I lingered in the garden until the inevitable swimming party had
+run up, chilled and exalted, from the black beach, until the lights
+were extinguished in the guestrooms overhead. When he came down the
+steps at last the tanned skin was drawn unusually tight on his face,
+and his eyes were bright and tired.
+
+“She didn’t like it,” he said immediately.
+
+“Of course she did.”
+
+“She didn’t like it,” he insisted. “She didn’t have a good time.”
+
+He was silent, and I guessed at his unutterable depression.
+
+“I feel far away from her,” he said. “It’s hard to make her
+understand.”
+
+“You mean about the dance?”
+
+“The dance?” He dismissed all the dances he had given with a snap of
+his fingers. “Old sport, the dance is unimportant.”
+
+He wanted nothing less of Daisy than that she should go to Tom and
+say: “I never loved you.” After she had obliterated four years with
+that sentence they could decide upon the more practical measures to be
+taken. One of them was that, after she was free, they were to go back
+to Louisville and be married from her house—just as if it were five
+years ago.
+
+“And she doesn’t understand,” he said. “She used to be able to
+understand. We’d sit for hours—”
+
+He broke off and began to walk up and down a desolate path of fruit
+rinds and discarded favours and crushed flowers.
+
+“I wouldn’t ask too much of her,” I ventured. “You can’t repeat the
+past.”
+
+“Can’t repeat the past?” he cried incredulously. “Why of course you
+can!”
+
+He looked around him wildly, as if the past were lurking here in the
+shadow of his house, just out of reach of his hand.
+
+“I’m going to fix everything just the way it was before,” he said,
+nodding determinedly. “She’ll see.”
+
+He talked a lot about the past, and I gathered that he wanted to
+recover something, some idea of himself perhaps, that had gone into
+loving Daisy. His life had been confused and disordered since then,
+but if he could once return to a certain starting place and go over it
+all slowly, he could find out what that thing was …
+
+… One autumn night, five years before, they had been walking down the
+street when the leaves were falling, and they came to a place where
+there were no trees and the sidewalk was white with moonlight. They
+stopped here and turned toward each other. Now it was a cool night
+with that mysterious excitement in it which comes at the two changes
+of the year. The quiet lights in the houses were humming out into the
+darkness and there was a stir and bustle among the stars. Out of the
+corner of his eye Gatsby saw that the blocks of the sidewalks really
+formed a ladder and mounted to a secret place above the trees—he could
+climb to it, if he climbed alone, and once there he could suck on the
+pap of life, gulp down the incomparable milk of wonder.
+
+His heart beat faster as Daisy’s white face came up to his own. He
+knew that when he kissed this girl, and forever wed his unutterable
+visions to her perishable breath, his mind would never romp again like
+the mind of God. So he waited, listening for a moment longer to the
+tuning-fork that had been struck upon a star. Then he kissed her. At
+his lips’ touch she blossomed for him like a flower and the
+incarnation was complete.
+
+Through all he said, even through his appalling sentimentality, I was
+reminded of something—an elusive rhythm, a fragment of lost words,
+that I had heard somewhere a long time ago. For a moment a phrase
+tried to take shape in my mouth and my lips parted like a dumb man’s,
+as though there was more struggling upon them than a wisp of startled
+air. But they made no sound, and what I had almost remembered was
+uncommunicable forever.
+
+
+                                 VII
+
+It was when curiosity about Gatsby was at its highest that the lights
+in his house failed to go on one Saturday night—and, as obscurely as
+it had begun, his career as Trimalchio was over. Only gradually did I
+become aware that the automobiles which turned expectantly into his
+drive stayed for just a minute and then drove sulkily away. Wondering
+if he were sick I went over to find out—an unfamiliar butler with a
+villainous face squinted at me suspiciously from the door.
+
+“Is Mr. Gatsby sick?”
+
+“Nope.” After a pause he added “sir” in a dilatory, grudging way.
+
+“I hadn’t seen him around, and I was rather worried. Tell him Mr.
+Carraway came over.”
+
+“Who?” he demanded rudely.
+
+“Carraway.”
+
+“Carraway. All right, I’ll tell him.”
+
+Abruptly he slammed the door.
+
+My Finn informed me that Gatsby had dismissed every servant in his
+house a week ago and replaced them with half a dozen others, who never
+went into West Egg village to be bribed by the tradesmen, but ordered
+moderate supplies over the telephone. The grocery boy reported that
+the kitchen looked like a pigsty, and the general opinion in the
+village was that the new people weren’t servants at all.
+
+Next day Gatsby called me on the phone.
+
+“Going away?” I inquired.
+
+“No, old sport.”
+
+“I hear you fired all your servants.”
+
+“I wanted somebody who wouldn’t gossip. Daisy comes over quite
+often—in the afternoons.”
+
+So the whole caravansary had fallen in like a card house at the
+disapproval in her eyes.
+
+“They’re some people Wolfshiem wanted to do something for. They’re all
+brothers and sisters. They used to run a small hotel.”
+
+“I see.”
+
+He was calling up at Daisy’s request—would I come to lunch at her
+house tomorrow? Miss Baker would be there. Half an hour later Daisy
+herself telephoned and seemed relieved to find that I was
+coming. Something was up. And yet I couldn’t believe that they would
+choose this occasion for a scene—especially for the rather harrowing
+scene that Gatsby had outlined in the garden.
+
+The next day was broiling, almost the last, certainly the warmest, of
+the summer. As my train emerged from the tunnel into sunlight, only
+the hot whistles of the National Biscuit Company broke the simmering
+hush at noon. The straw seats of the car hovered on the edge of
+combustion; the woman next to me perspired delicately for a while into
+her white shirtwaist, and then, as her newspaper dampened under her
+fingers, lapsed despairingly into deep heat with a desolate cry. Her
+pocketbook slapped to the floor.
+
+“Oh, my!” she gasped.
+
+I picked it up with a weary bend and handed it back to her, holding it
+at arm’s length and by the extreme tip of the corners to indicate that
+I had no designs upon it—but everyone near by, including the woman,
+suspected me just the same.
+
+“Hot!” said the conductor to familiar faces. “Some weather! … Hot! …
+Hot! … Hot! … Is it hot enough for you? Is it hot? Is it … ?”
+
+My commutation ticket came back to me with a dark stain from his hand.
+That anyone should care in this heat whose flushed lips he kissed,
+whose head made damp the pyjama pocket over his heart!
+
+… Through the hall of the Buchanans’ house blew a faint wind, carrying
+the sound of the telephone bell out to Gatsby and me as we waited at
+the door.
+
+“The master’s body?” roared the butler into the mouthpiece. “I’m
+sorry, madame, but we can’t furnish it—it’s far too hot to touch this
+noon!”
+
+What he really said was: “Yes … Yes … I’ll see.”
+
+He set down the receiver and came toward us, glistening slightly, to
+take our stiff straw hats.
+
+“Madame expects you in the salon!” he cried, needlessly indicating the
+direction. In this heat every extra gesture was an affront to the
+common store of life.
+
+The room, shadowed well with awnings, was dark and cool. Daisy and
+Jordan lay upon an enormous couch, like silver idols weighing down
+their own white dresses against the singing breeze of the fans.
+
+“We can’t move,” they said together.
+
+Jordan’s fingers, powdered white over their tan, rested for a moment
+in mine.
+
+“And Mr. Thomas Buchanan, the athlete?” I inquired.
+
+Simultaneously I heard his voice, gruff, muffled, husky, at the hall
+telephone.
+
+Gatsby stood in the centre of the crimson carpet and gazed around with
+fascinated eyes. Daisy watched him and laughed, her sweet, exciting
+laugh; a tiny gust of powder rose from her bosom into the air.
+
+“The rumour is,” whispered Jordan, “that that’s Tom’s girl on the
+telephone.”
+
+We were silent. The voice in the hall rose high with annoyance: “Very
+well, then, I won’t sell you the car at all … I’m under no obligations
+to you at all … and as for your bothering me about it at lunch time, I
+won’t stand that at all!”
+
+“Holding down the receiver,” said Daisy cynically.
+
+“No, he’s not,” I assured her. “It’s a bona-fide deal. I happen to
+know about it.”
+
+Tom flung open the door, blocked out its space for a moment with his
+thick body, and hurried into the room.
+
+“Mr. Gatsby!” He put out his broad, flat hand with well-concealed
+dislike. “I’m glad to see you, sir … Nick …”
+
+“Make us a cold drink,” cried Daisy.
+
+As he left the room again she got up and went over to Gatsby and
+pulled his face down, kissing him on the mouth.
+
+“You know I love you,” she murmured.
+
+“You forget there’s a lady present,” said Jordan.
+
+Daisy looked around doubtfully.
+
+“You kiss Nick too.”
+
+“What a low, vulgar girl!”
+
+“I don’t care!” cried Daisy, and began to clog on the brick fireplace.
+Then she remembered the heat and sat down guiltily on the couch just
+as a freshly laundered nurse leading a little girl came into the room.
+
+“Bles-sed pre-cious,” she crooned, holding out her arms. “Come to your
+own mother that loves you.”
+
+The child, relinquished by the nurse, rushed across the room and
+rooted shyly into her mother’s dress.
+
+“The bles-sed pre-cious! Did mother get powder on your old yellowy
+hair? Stand up now, and say—How-de-do.”
+
+Gatsby and I in turn leaned down and took the small reluctant hand.
+Afterward he kept looking at the child with surprise. I don’t think he
+had ever really believed in its existence before.
+
+“I got dressed before luncheon,” said the child, turning eagerly to
+Daisy.
+
+“That’s because your mother wanted to show you off.” Her face bent
+into the single wrinkle of the small white neck. “You dream, you. You
+absolute little dream.”
+
+“Yes,” admitted the child calmly. “Aunt Jordan’s got on a white dress
+too.”
+
+“How do you like mother’s friends?” Daisy turned her around so that
+she faced Gatsby. “Do you think they’re pretty?”
+
+“Where’s Daddy?”
+
+“She doesn’t look like her father,” explained Daisy. “She looks like
+me. She’s got my hair and shape of the face.”
+
+Daisy sat back upon the couch. The nurse took a step forward and held
+out her hand.
+
+“Come, Pammy.”
+
+“Goodbye, sweetheart!”
+
+With a reluctant backward glance the well-disciplined child held to
+her nurse’s hand and was pulled out the door, just as Tom came back,
+preceding four gin rickeys that clicked full of ice.
+
+Gatsby took up his drink.
+
+“They certainly look cool,” he said, with visible tension.
+
+We drank in long, greedy swallows.
+
+“I read somewhere that the sun’s getting hotter every year,” said Tom
+genially. “It seems that pretty soon the earth’s going to fall into
+the sun—or wait a minute—it’s just the opposite—the sun’s getting
+colder every year.
+
+“Come outside,” he suggested to Gatsby, “I’d like you to have a look
+at the place.”
+
+I went with them out to the veranda. On the green Sound, stagnant in
+the heat, one small sail crawled slowly toward the fresher sea.
+Gatsby’s eyes followed it momentarily; he raised his hand and pointed
+across the bay.
+
+“I’m right across from you.”
+
+“So you are.”
+
+Our eyes lifted over the rose-beds and the hot lawn and the weedy
+refuse of the dog-days alongshore. Slowly the white wings of the boat
+moved against the blue cool limit of the sky. Ahead lay the scalloped
+ocean and the abounding blessed isles.
+
+“There’s sport for you,” said Tom, nodding. “I’d like to be out there
+with him for about an hour.”
+
+We had luncheon in the dining-room, darkened too against the heat, and
+drank down nervous gaiety with the cold ale.
+
+“What’ll we do with ourselves this afternoon?” cried Daisy, “and the
+day after that, and the next thirty years?”
+
+“Don’t be morbid,” Jordan said. “Life starts all over again when it
+gets crisp in the fall.”
+
+“But it’s so hot,” insisted Daisy, on the verge of tears, “and
+everything’s so confused. Let’s all go to town!”
+
+Her voice struggled on through the heat, beating against it, moulding
+its senselessness into forms.
+
+“I’ve heard of making a garage out of a stable,” Tom was saying to
+Gatsby, “but I’m the first man who ever made a stable out of a
+garage.”
+
+“Who wants to go to town?” demanded Daisy insistently. Gatsby’s eyes
+floated toward her. “Ah,” she cried, “you look so cool.”
+
+Their eyes met, and they stared together at each other, alone in
+space. With an effort she glanced down at the table.
+
+“You always look so cool,” she repeated.
+
+She had told him that she loved him, and Tom Buchanan saw. He was
+astounded. His mouth opened a little, and he looked at Gatsby, and
+then back at Daisy as if he had just recognized her as someone he knew
+a long time ago.
+
+“You resemble the advertisement of the man,” she went on innocently.
+“You know the advertisement of the man—”
+
+“All right,” broke in Tom quickly, “I’m perfectly willing to go to
+town. Come on—we’re all going to town.”
+
+He got up, his eyes still flashing between Gatsby and his wife. No one
+moved.
+
+“Come on!” His temper cracked a little. “What’s the matter, anyhow?
+If we’re going to town, let’s start.”
+
+His hand, trembling with his effort at self-control, bore to his lips
+the last of his glass of ale. Daisy’s voice got us to our feet and out
+on to the blazing gravel drive.
+
+“Are we just going to go?” she objected. “Like this? Aren’t we going
+to let anyone smoke a cigarette first?”
+
+“Everybody smoked all through lunch.”
+
+“Oh, let’s have fun,” she begged him. “It’s too hot to fuss.”
+
+He didn’t answer.
+
+“Have it your own way,” she said. “Come on, Jordan.”
+
+They went upstairs to get ready while we three men stood there
+shuffling the hot pebbles with our feet. A silver curve of the moon
+hovered already in the western sky. Gatsby started to speak, changed
+his mind, but not before Tom wheeled and faced him expectantly.
+
+“Have you got your stables here?” asked Gatsby with an effort.
+
+“About a quarter of a mile down the road.”
+
+“Oh.”
+
+A pause.
+
+“I don’t see the idea of going to town,” broke out Tom savagely.
+“Women get these notions in their heads—”
+
+“Shall we take anything to drink?” called Daisy from an upper window.
+
+“I’ll get some whisky,” answered Tom. He went inside.
+
+Gatsby turned to me rigidly:
+
+“I can’t say anything in his house, old sport.”
+
+“She’s got an indiscreet voice,” I remarked. “It’s full of—” I
+hesitated.
+
+“Her voice is full of money,” he said suddenly.
+
+That was it. I’d never understood before. It was full of money—that
+was the inexhaustible charm that rose and fell in it, the jingle of
+it, the cymbals’ song of it … High in a white palace the king’s
+daughter, the golden girl …
+
+Tom came out of the house wrapping a quart bottle in a towel, followed
+by Daisy and Jordan wearing small tight hats of metallic cloth and
+carrying light capes over their arms.
+
+“Shall we all go in my car?” suggested Gatsby. He felt the hot, green
+leather of the seat. “I ought to have left it in the shade.”
+
+“Is it standard shift?” demanded Tom.
+
+“Yes.”
+
+“Well, you take my coupé and let me drive your car to town.”
+
+The suggestion was distasteful to Gatsby.
+
+“I don’t think there’s much gas,” he objected.
+
+“Plenty of gas,” said Tom boisterously. He looked at the gauge. “And
+if it runs out I can stop at a drugstore. You can buy anything at a
+drugstore nowadays.”
+
+A pause followed this apparently pointless remark. Daisy looked at Tom
+frowning, and an indefinable expression, at once definitely unfamiliar
+and vaguely recognizable, as if I had only heard it described in
+words, passed over Gatsby’s face.
+
+“Come on, Daisy” said Tom, pressing her with his hand toward Gatsby’s
+car. “I’ll take you in this circus wagon.”
+
+He opened the door, but she moved out from the circle of his arm.
+
+“You take Nick and Jordan. We’ll follow you in the coupé.”
+
+She walked close to Gatsby, touching his coat with her hand. Jordan
+and Tom and I got into the front seat of Gatsby’s car, Tom pushed the
+unfamiliar gears tentatively, and we shot off into the oppressive
+heat, leaving them out of sight behind.
+
+“Did you see that?” demanded Tom.
+
+“See what?”
+
+He looked at me keenly, realizing that Jordan and I must have known
+all along.
+
+“You think I’m pretty dumb, don’t you?” he suggested. “Perhaps I am,
+but I have a—almost a second sight, sometimes, that tells me what to
+do. Maybe you don’t believe that, but science—”
+
+He paused. The immediate contingency overtook him, pulled him back
+from the edge of theoretical abyss.
+
+“I’ve made a small investigation of this fellow,” he continued. “I
+could have gone deeper if I’d known—”
+
+“Do you mean you’ve been to a medium?” inquired Jordan humorously.
+
+“What?” Confused, he stared at us as we laughed. “A medium?”
+
+“About Gatsby.”
+
+“About Gatsby! No, I haven’t. I said I’d been making a small
+investigation of his past.”
+
+“And you found he was an Oxford man,” said Jordan helpfully.
+
+“An Oxford man!” He was incredulous. “Like hell he is! He wears a pink
+suit.”
+
+“Nevertheless he’s an Oxford man.”
+
+“Oxford, New Mexico,” snorted Tom contemptuously, “or something like
+that.”
+
+“Listen, Tom. If you’re such a snob, why did you invite him to lunch?”
+demanded Jordan crossly.
+
+“Daisy invited him; she knew him before we were married—God knows
+where!”
+
+We were all irritable now with the fading ale, and aware of it we
+drove for a while in silence. Then as Doctor T. J. Eckleburg’s faded
+eyes came into sight down the road, I remembered Gatsby’s caution
+about gasoline.
+
+“We’ve got enough to get us to town,” said Tom.
+
+“But there’s a garage right here,” objected Jordan. “I don’t want to
+get stalled in this baking heat.”
+
+Tom threw on both brakes impatiently, and we slid to an abrupt dusty
+stop under Wilson’s sign. After a moment the proprietor emerged from
+the interior of his establishment and gazed hollow-eyed at the car.
+
+“Let’s have some gas!” cried Tom roughly. “What do you think we
+stopped for—to admire the view?”
+
+“I’m sick,” said Wilson without moving. “Been sick all day.”
+
+“What’s the matter?”
+
+“I’m all run down.”
+
+“Well, shall I help myself?” Tom demanded. “You sounded well enough on
+the phone.”
+
+With an effort Wilson left the shade and support of the doorway and,
+breathing hard, unscrewed the cap of the tank. In the sunlight his
+face was green.
+
+“I didn’t mean to interrupt your lunch,” he said. “But I need money
+pretty bad, and I was wondering what you were going to do with your
+old car.”
+
+“How do you like this one?” inquired Tom. “I bought it last week.”
+
+“It’s a nice yellow one,” said Wilson, as he strained at the handle.
+
+“Like to buy it?”
+
+“Big chance,” Wilson smiled faintly. “No, but I could make some money
+on the other.”
+
+“What do you want money for, all of a sudden?”
+
+“I’ve been here too long. I want to get away. My wife and I want to go
+West.”
+
+“Your wife does,” exclaimed Tom, startled.
+
+“She’s been talking about it for ten years.” He rested for a moment
+against the pump, shading his eyes. “And now she’s going whether she
+wants to or not. I’m going to get her away.”
+
+The coupé flashed by us with a flurry of dust and the flash of a
+waving hand.
+
+“What do I owe you?” demanded Tom harshly.
+
+“I just got wised up to something funny the last two days,” remarked
+Wilson. “That’s why I want to get away. That’s why I been bothering
+you about the car.”
+
+“What do I owe you?”
+
+“Dollar twenty.”
+
+The relentless beating heat was beginning to confuse me and I had a
+bad moment there before I realized that so far his suspicions hadn’t
+alighted on Tom. He had discovered that Myrtle had some sort of life
+apart from him in another world, and the shock had made him physically
+sick. I stared at him and then at Tom, who had made a parallel
+discovery less than an hour before—and it occurred to me that there
+was no difference between men, in intelligence or race, so profound as
+the difference between the sick and the well. Wilson was so sick that
+he looked guilty, unforgivably guilty—as if he had just got some poor
+girl with child.
+
+“I’ll let you have that car,” said Tom. “I’ll send it over tomorrow
+afternoon.”
+
+That locality was always vaguely disquieting, even in the broad glare
+of afternoon, and now I turned my head as though I had been warned of
+something behind. Over the ash-heaps the giant eyes of Doctor T. J.
+Eckleburg kept their vigil, but I perceived, after a moment, that
+other eyes were regarding us with peculiar intensity from less than
+twenty feet away.
+
+In one of the windows over the garage the curtains had been moved
+aside a little, and Myrtle Wilson was peering down at the car. So
+engrossed was she that she had no consciousness of being observed, and
+one emotion after another crept into her face like objects into a
+slowly developing picture. Her expression was curiously familiar—it
+was an expression I had often seen on women’s faces, but on Myrtle
+Wilson’s face it seemed purposeless and inexplicable until I realized
+that her eyes, wide with jealous terror, were fixed not on Tom, but on
+Jordan Baker, whom she took to be his wife.
+
+------------------------------------------------------------------------
+
+There is no confusion like the confusion of a simple mind, and as we
+drove away Tom was feeling the hot whips of panic. His wife and his
+mistress, until an hour ago secure and inviolate, were slipping
+precipitately from his control. Instinct made him step on the
+accelerator with the double purpose of overtaking Daisy and leaving
+Wilson behind, and we sped along toward Astoria at fifty miles an
+hour, until, among the spidery girders of the elevated, we came in
+sight of the easygoing blue coupé.
+
+“Those big movies around Fiftieth Street are cool,” suggested
+Jordan. “I love New York on summer afternoons when everyone’s away.
+There’s something very sensuous about it—overripe, as if all sorts of
+funny fruits were going to fall into your hands.”
+
+The word “sensuous” had the effect of further disquieting Tom, but
+before he could invent a protest the coupé came to a stop, and Daisy
+signalled us to draw up alongside.
+
+“Where are we going?” she cried.
+
+“How about the movies?”
+
+“It’s so hot,” she complained. “You go. We’ll ride around and meet you
+after.” With an effort her wit rose faintly. “We’ll meet you on some
+corner. I’ll be the man smoking two cigarettes.”
+
+“We can’t argue about it here,” Tom said impatiently, as a truck gave
+out a cursing whistle behind us. “You follow me to the south side of
+Central Park, in front of the Plaza.”
+
+Several times he turned his head and looked back for their car, and if
+the traffic delayed them he slowed up until they came into sight. I
+think he was afraid they would dart down a side-street and out of his
+life forever.
+
+But they didn’t. And we all took the less explicable step of engaging
+the parlour of a suite in the Plaza Hotel.
+
+The prolonged and tumultuous argument that ended by herding us into
+that room eludes me, though I have a sharp physical memory that, in
+the course of it, my underwear kept climbing like a damp snake around
+my legs and intermittent beads of sweat raced cool across my back.
+The notion originated with Daisy’s suggestion that we hire five
+bathrooms and take cold baths, and then assumed more tangible form as
+“a place to have a mint julep.” Each of us said over and over that it
+was a “crazy idea”—we all talked at once to a baffled clerk and
+thought, or pretended to think, that we were being very funny …
+
+The room was large and stifling, and, though it was already four
+o’clock, opening the windows admitted only a gust of hot shrubbery
+from the Park. Daisy went to the mirror and stood with her back to us,
+fixing her hair.
+
+“It’s a swell suite,” whispered Jordan respectfully, and everyone
+laughed.
+
+“Open another window,” commanded Daisy, without turning around.
+
+“There aren’t any more.”
+
+“Well, we’d better telephone for an axe—”
+
+“The thing to do is to forget about the heat,” said Tom impatiently.
+“You make it ten times worse by crabbing about it.”
+
+He unrolled the bottle of whisky from the towel and put it on the
+table.
+
+“Why not let her alone, old sport?” remarked Gatsby. “You’re the one
+that wanted to come to town.”
+
+There was a moment of silence. The telephone book slipped from its
+nail and splashed to the floor, whereupon Jordan whispered, “Excuse
+me”—but this time no one laughed.
+
+“I’ll pick it up,” I offered.
+
+“I’ve got it.” Gatsby examined the parted string, muttered “Hum!” in
+an interested way, and tossed the book on a chair.
+
+“That’s a great expression of yours, isn’t it?” said Tom sharply.
+
+“What is?”
+
+“All this ‘old sport’ business. Where’d you pick that up?”
+
+“Now see here, Tom,” said Daisy, turning around from the mirror, “if
+you’re going to make personal remarks I won’t stay here a minute.
+Call up and order some ice for the mint julep.”
+
+As Tom took up the receiver the compressed heat exploded into sound
+and we were listening to the portentous chords of Mendelssohn’s
+Wedding March from the ballroom below.
+
+“Imagine marrying anybody in this heat!” cried Jordan dismally.
+
+“Still—I was married in the middle of June,” Daisy remembered.
+“Louisville in June! Somebody fainted. Who was it fainted, Tom?”
+
+“Biloxi,” he answered shortly.
+
+“A man named Biloxi. ‘Blocks’ Biloxi, and he made boxes—that’s a
+fact—and he was from Biloxi, Tennessee.”
+
+“They carried him into my house,” appended Jordan, “because we lived
+just two doors from the church. And he stayed three weeks, until Daddy
+told him he had to get out. The day after he left Daddy died.”  After
+a moment she added. “There wasn’t any connection.”
+
+“I used to know a Bill Biloxi from Memphis,” I remarked.
+
+“That was his cousin. I knew his whole family history before he
+left. He gave me an aluminium putter that I use today.”
+
+The music had died down as the ceremony began and now a long cheer
+floated in at the window, followed by intermittent cries of
+“Yea—ea—ea!” and finally by a burst of jazz as the dancing began.
+
+“We’re getting old,” said Daisy. “If we were young we’d rise and
+dance.”
+
+“Remember Biloxi,” Jordan warned her. “Where’d you know him, Tom?”
+
+“Biloxi?” He concentrated with an effort. “I didn’t know him. He was a
+friend of Daisy’s.”
+
+“He was not,” she denied. “I’d never seen him before. He came down in
+the private car.”
+
+“Well, he said he knew you. He said he was raised in Louisville. Asa
+Bird brought him around at the last minute and asked if we had room
+for him.”
+
+Jordan smiled.
+
+“He was probably bumming his way home. He told me he was president of
+your class at Yale.”
+
+Tom and I looked at each other blankly.
+
+“Biloxi?”
+
+“First place, we didn’t have any president—”
+
+Gatsby’s foot beat a short, restless tattoo and Tom eyed him suddenly.
+
+“By the way, Mr. Gatsby, I understand you’re an Oxford man.”
+
+“Not exactly.”
+
+“Oh, yes, I understand you went to Oxford.”
+
+“Yes—I went there.”
+
+A pause. Then Tom’s voice, incredulous and insulting:
+
+“You must have gone there about the time Biloxi went to New Haven.”
+
+Another pause. A waiter knocked and came in with crushed mint and ice
+but the silence was unbroken by his “thank you” and the soft closing
+of the door. This tremendous detail was to be cleared up at last.
+
+“I told you I went there,” said Gatsby.
+
+“I heard you, but I’d like to know when.”
+
+“It was in nineteen-nineteen, I only stayed five months. That’s why I
+can’t really call myself an Oxford man.”
+
+Tom glanced around to see if we mirrored his unbelief. But we were all
+looking at Gatsby.
+
+“It was an opportunity they gave to some of the officers after the
+armistice,” he continued. “We could go to any of the universities in
+England or France.”
+
+I wanted to get up and slap him on the back. I had one of those
+renewals of complete faith in him that I’d experienced before.
+
+Daisy rose, smiling faintly, and went to the table.
+
+“Open the whisky, Tom,” she ordered, “and I’ll make you a mint julep.
+Then you won’t seem so stupid to yourself … Look at the mint!”
+
+“Wait a minute,” snapped Tom, “I want to ask Mr. Gatsby one more
+question.”
+
+“Go on,” Gatsby said politely.
+
+“What kind of a row are you trying to cause in my house anyhow?”
+
+They were out in the open at last and Gatsby was content.
+
+“He isn’t causing a row,” Daisy looked desperately from one to the
+other. “You’re causing a row. Please have a little self-control.”
+
+“Self-control!” repeated Tom incredulously. “I suppose the latest
+thing is to sit back and let Mr. Nobody from Nowhere make love to your
+wife. Well, if that’s the idea you can count me out … Nowadays people
+begin by sneering at family life and family institutions, and next
+they’ll throw everything overboard and have intermarriage between
+black and white.”
+
+Flushed with his impassioned gibberish, he saw himself standing alone
+on the last barrier of civilization.
+
+“We’re all white here,” murmured Jordan.
+
+“I know I’m not very popular. I don’t give big parties. I suppose
+you’ve got to make your house into a pigsty in order to have any
+friends—in the modern world.”
+
+Angry as I was, as we all were, I was tempted to laugh whenever he
+opened his mouth. The transition from libertine to prig was so
+complete.
+
+“I’ve got something to tell you, old sport—” began Gatsby. But Daisy
+guessed at his intention.
+
+“Please don’t!” she interrupted helplessly. “Please let’s all go
+home. Why don’t we all go home?”
+
+“That’s a good idea,” I got up. “Come on, Tom. Nobody wants a drink.”
+
+“I want to know what Mr. Gatsby has to tell me.”
+
+“Your wife doesn’t love you,” said Gatsby. “She’s never loved you.
+She loves me.”
+
+“You must be crazy!” exclaimed Tom automatically.
+
+Gatsby sprang to his feet, vivid with excitement.
+
+“She never loved you, do you hear?” he cried. “She only married you
+because I was poor and she was tired of waiting for me. It was a
+terrible mistake, but in her heart she never loved anyone except me!”
+
+At this point Jordan and I tried to go, but Tom and Gatsby insisted
+with competitive firmness that we remain—as though neither of them had
+anything to conceal and it would be a privilege to partake vicariously
+of their emotions.
+
+“Sit down, Daisy,” Tom’s voice groped unsuccessfully for the paternal
+note. “What’s been going on? I want to hear all about it.”
+
+“I told you what’s been going on,” said Gatsby. “Going on for five
+years—and you didn’t know.”
+
+Tom turned to Daisy sharply.
+
+“You’ve been seeing this fellow for five years?”
+
+“Not seeing,” said Gatsby. “No, we couldn’t meet. But both of us loved
+each other all that time, old sport, and you didn’t know. I used to
+laugh sometimes”—but there was no laughter in his eyes—“to think that
+you didn’t know.”
+
+“Oh—that’s all.” Tom tapped his thick fingers together like a
+clergyman and leaned back in his chair.
+
+“You’re crazy!” he exploded. “I can’t speak about what happened five
+years ago, because I didn’t know Daisy then—and I’ll be damned if I
+see how you got within a mile of her unless you brought the groceries
+to the back door. But all the rest of that’s a God damned lie. Daisy
+loved me when she married me and she loves me now.”
+
+“No,” said Gatsby, shaking his head.
+
+“She does, though. The trouble is that sometimes she gets foolish
+ideas in her head and doesn’t know what she’s doing.” He nodded
+sagely. “And what’s more, I love Daisy too. Once in a while I go off
+on a spree and make a fool of myself, but I always come back, and in
+my heart I love her all the time.”
+
+“You’re revolting,” said Daisy. She turned to me, and her voice,
+dropping an octave lower, filled the room with thrilling scorn: “Do
+you know why we left Chicago? I’m surprised that they didn’t treat you
+to the story of that little spree.”
+
+Gatsby walked over and stood beside her.
+
+“Daisy, that’s all over now,” he said earnestly. “It doesn’t matter
+any more. Just tell him the truth—that you never loved him—and it’s
+all wiped out forever.”
+
+She looked at him blindly. “Why—how could I love him—possibly?”
+
+“You never loved him.”
+
+She hesitated. Her eyes fell on Jordan and me with a sort of appeal,
+as though she realized at last what she was doing—and as though she
+had never, all along, intended doing anything at all. But it was done
+now. It was too late.
+
+“I never loved him,” she said, with perceptible reluctance.
+
+“Not at Kapiolani?” demanded Tom suddenly.
+
+“No.”
+
+From the ballroom beneath, muffled and suffocating chords were
+drifting up on hot waves of air.
+
+“Not that day I carried you down from the Punch Bowl to keep your
+shoes dry?” There was a husky tenderness in his tone … “Daisy?”
+
+“Please don’t.” Her voice was cold, but the rancour was gone from it.
+She looked at Gatsby. “There, Jay,” she said—but her hand as she tried
+to light a cigarette was trembling. Suddenly she threw the cigarette
+and the burning match on the carpet.
+
+“Oh, you want too much!” she cried to Gatsby. “I love you now—isn’t
+that enough? I can’t help what’s past.” She began to sob
+helplessly. “I did love him once—but I loved you too.”
+
+Gatsby’s eyes opened and closed.
+
+“You loved me too?” he repeated.
+
+“Even that’s a lie,” said Tom savagely. “She didn’t know you were
+alive. Why—there’s things between Daisy and me that you’ll never know,
+things that neither of us can ever forget.”
+
+The words seemed to bite physically into Gatsby.
+
+“I want to speak to Daisy alone,” he insisted. “She’s all excited
+now—”
+
+“Even alone I can’t say I never loved Tom,” she admitted in a pitiful
+voice. “It wouldn’t be true.”
+
+“Of course it wouldn’t,” agreed Tom.
+
+She turned to her husband.
+
+“As if it mattered to you,” she said.
+
+“Of course it matters. I’m going to take better care of you from now
+on.”
+
+“You don’t understand,” said Gatsby, with a touch of panic. “You’re
+not going to take care of her any more.”
+
+“I’m not?” Tom opened his eyes wide and laughed. He could afford to
+control himself now. “Why’s that?”
+
+“Daisy’s leaving you.”
+
+“Nonsense.”
+
+“I am, though,” she said with a visible effort.
+
+“She’s not leaving me!” Tom’s words suddenly leaned down over Gatsby.
+“Certainly not for a common swindler who’d have to steal the ring he
+put on her finger.”
+
+“I won’t stand this!” cried Daisy. “Oh, please let’s get out.”
+
+“Who are you, anyhow?” broke out Tom. “You’re one of that bunch that
+hangs around with Meyer Wolfshiem—that much I happen to know. I’ve
+made a little investigation into your affairs—and I’ll carry it
+further tomorrow.”
+
+“You can suit yourself about that, old sport,” said Gatsby steadily.
+
+“I found out what your ‘drugstores’ were.” He turned to us and spoke
+rapidly. “He and this Wolfshiem bought up a lot of side-street
+drugstores here and in Chicago and sold grain alcohol over the
+counter. That’s one of his little stunts. I picked him for a
+bootlegger the first time I saw him, and I wasn’t far wrong.”
+
+“What about it?” said Gatsby politely. “I guess your friend Walter
+Chase wasn’t too proud to come in on it.”
+
+“And you left him in the lurch, didn’t you? You let him go to jail for
+a month over in New Jersey. God! You ought to hear Walter on the
+subject of you.”
+
+“He came to us dead broke. He was very glad to pick up some money, old
+sport.”
+
+“Don’t you call me ‘old sport’!” cried Tom. Gatsby said
+nothing. “Walter could have you up on the betting laws too, but
+Wolfshiem scared him into shutting his mouth.”
+
+That unfamiliar yet recognizable look was back again in Gatsby’s face.
+
+“That drugstore business was just small change,” continued Tom slowly,
+“but you’ve got something on now that Walter’s afraid to tell me
+about.”
+
+I glanced at Daisy, who was staring terrified between Gatsby and her
+husband, and at Jordan, who had begun to balance an invisible but
+absorbing object on the tip of her chin. Then I turned back to
+Gatsby—and was startled at his expression. He looked—and this is said
+in all contempt for the babbled slander of his garden—as if he had
+“killed a man.” For a moment the set of his face could be described in
+just that fantastic way.
+
+It passed, and he began to talk excitedly to Daisy, denying
+everything, defending his name against accusations that had not been
+made. But with every word she was drawing further and further into
+herself, so he gave that up, and only the dead dream fought on as the
+afternoon slipped away, trying to touch what was no longer tangible,
+struggling unhappily, undespairingly, toward that lost voice across
+the room.
+
+The voice begged again to go.
+
+“Please, Tom! I can’t stand this any more.”
+
+Her frightened eyes told that whatever intentions, whatever courage
+she had had, were definitely gone.
+
+“You two start on home, Daisy,” said Tom. “In Mr. Gatsby’s car.”
+
+She looked at Tom, alarmed now, but he insisted with magnanimous
+scorn.
+
+“Go on. He won’t annoy you. I think he realizes that his presumptuous
+little flirtation is over.”
+
+They were gone, without a word, snapped out, made accidental,
+isolated, like ghosts, even from our pity.
+
+After a moment Tom got up and began wrapping the unopened bottle of
+whisky in the towel.
+
+“Want any of this stuff? Jordan? … Nick?”
+
+I didn’t answer.
+
+“Nick?” He asked again.
+
+“What?”
+
+“Want any?”
+
+“No … I just remembered that today’s my birthday.”
+
+I was thirty. Before me stretched the portentous, menacing road of a
+new decade.
+
+It was seven o’clock when we got into the coupé with him and started
+for Long Island. Tom talked incessantly, exulting and laughing, but
+his voice was as remote from Jordan and me as the foreign clamour on
+the sidewalk or the tumult of the elevated overhead. Human sympathy
+has its limits, and we were content to let all their tragic arguments
+fade with the city lights behind. Thirty—the promise of a decade of
+loneliness, a thinning list of single men to know, a thinning
+briefcase of enthusiasm, thinning hair. But there was Jordan beside
+me, who, unlike Daisy, was too wise ever to carry well-forgotten
+dreams from age to age. As we passed over the dark bridge her wan face
+fell lazily against my coat’s shoulder and the formidable stroke of
+thirty died away with the reassuring pressure of her hand.
+
+So we drove on toward death through the cooling twilight.
+
+------------------------------------------------------------------------
+
+The young Greek, Michaelis, who ran the coffee joint beside the
+ash-heaps was the principal witness at the inquest. He had slept
+through the heat until after five, when he strolled over to the
+garage, and found George Wilson sick in his office—really sick, pale
+as his own pale hair and shaking all over. Michaelis advised him to go
+to bed, but Wilson refused, saying that he’d miss a lot of business if
+he did. While his neighbour was trying to persuade him a violent
+racket broke out overhead.
+
+“I’ve got my wife locked in up there,” explained Wilson calmly.
+“She’s going to stay there till the day after tomorrow, and then we’re
+going to move away.”
+
+Michaelis was astonished; they had been neighbours for four years, and
+Wilson had never seemed faintly capable of such a statement.
+Generally he was one of these worn-out men: when he wasn’t working, he
+sat on a chair in the doorway and stared at the people and the cars
+that passed along the road. When anyone spoke to him he invariably
+laughed in an agreeable, colourless way. He was his wife’s man and not
+his own.
+
+So naturally Michaelis tried to find out what had happened, but Wilson
+wouldn’t say a word—instead he began to throw curious, suspicious
+glances at his visitor and ask him what he’d been doing at certain
+times on certain days. Just as the latter was getting uneasy, some
+workmen came past the door bound for his restaurant, and Michaelis
+took the opportunity to get away, intending to come back later. But he
+didn’t. He supposed he forgot to, that’s all. When he came outside
+again, a little after seven, he was reminded of the conversation
+because he heard Mrs. Wilson’s voice, loud and scolding, downstairs in
+the garage.
+
+“Beat me!” he heard her cry. “Throw me down and beat me, you dirty
+little coward!”
+
+A moment later she rushed out into the dusk, waving her hands and
+shouting—before he could move from his door the business was over.
+
+The “death car” as the newspapers called it, didn’t stop; it came out
+of the gathering darkness, wavered tragically for a moment, and then
+disappeared around the next bend. Mavro Michaelis wasn’t even sure of
+its colour—he told the first policeman that it was light green. The
+other car, the one going toward New York, came to rest a hundred yards
+beyond, and its driver hurried back to where Myrtle Wilson, her life
+violently extinguished, knelt in the road and mingled her thick dark
+blood with the dust.
+
+Michaelis and this man reached her first, but when they had torn open
+her shirtwaist, still damp with perspiration, they saw that her left
+breast was swinging loose like a flap, and there was no need to listen
+for the heart beneath. The mouth was wide open and ripped a little at
+the corners, as though she had choked a little in giving up the
+tremendous vitality she had stored so long.
+
+------------------------------------------------------------------------
+
+We saw the three or four automobiles and the crowd when we were still
+some distance away.
+
+“Wreck!” said Tom. “That’s good. Wilson’ll have a little business at
+last.”
+
+He slowed down, but still without any intention of stopping, until, as
+we came nearer, the hushed, intent faces of the people at the garage
+door made him automatically put on the brakes.
+
+“We’ll take a look,” he said doubtfully, “just a look.”
+
+I became aware now of a hollow, wailing sound which issued incessantly
+from the garage, a sound which as we got out of the coupé and walked
+toward the door resolved itself into the words “Oh, my God!” uttered
+over and over in a gasping moan.
+
+“There’s some bad trouble here,” said Tom excitedly.
+
+He reached up on tiptoes and peered over a circle of heads into the
+garage, which was lit only by a yellow light in a swinging metal
+basket overhead. Then he made a harsh sound in his throat, and with a
+violent thrusting movement of his powerful arms pushed his way
+through.
+
+The circle closed up again with a running murmur of expostulation; it
+was a minute before I could see anything at all. Then new arrivals
+deranged the line, and Jordan and I were pushed suddenly inside.
+
+Myrtle Wilson’s body, wrapped in a blanket, and then in another
+blanket, as though she suffered from a chill in the hot night, lay on
+a worktable by the wall, and Tom, with his back to us, was bending
+over it, motionless. Next to him stood a motorcycle policeman taking
+down names with much sweat and correction in a little book. At first I
+couldn’t find the source of the high, groaning words that echoed
+clamorously through the bare garage—then I saw Wilson standing on the
+raised threshold of his office, swaying back and forth and holding to
+the doorposts with both hands. Some man was talking to him in a low
+voice and attempting, from time to time, to lay a hand on his
+shoulder, but Wilson neither heard nor saw. His eyes would drop slowly
+from the swinging light to the laden table by the wall, and then jerk
+back to the light again, and he gave out incessantly his high,
+horrible call:
+
+“Oh, my Ga-od! Oh, my Ga-od! Oh, Ga-od! Oh, my Ga-od!”
+
+Presently Tom lifted his head with a jerk and, after staring around
+the garage with glazed eyes, addressed a mumbled incoherent remark to
+the policeman.
+
+“M-a-v—” the policeman was saying, “—o—”
+
+“No, r—” corrected the man, “M-a-v-r-o—”
+
+“Listen to me!” muttered Tom fiercely.
+
+“r—” said the policeman, “o—”
+
+“g—”
+
+“g—” He looked up as Tom’s broad hand fell sharply on his shoulder.
+“What you want, fella?”
+
+“What happened?—that’s what I want to know.”
+
+“Auto hit her. Ins’antly killed.”
+
+“Instantly killed,” repeated Tom, staring.
+
+“She ran out ina road. Son-of-a-bitch didn’t even stopus car.”
+
+“There was two cars,” said Michaelis, “one comin’, one goin’, see?”
+
+“Going where?” asked the policeman keenly.
+
+“One goin’ each way. Well, she”—his hand rose toward the blankets but
+stopped halfway and fell to his side—“she ran out there an’ the one
+comin’ from N’York knock right into her, goin’ thirty or forty miles
+an hour.”
+
+“What’s the name of this place here?” demanded the officer.
+
+“Hasn’t got any name.”
+
+A pale well-dressed negro stepped near.
+
+“It was a yellow car,” he said, “big yellow car. New.”
+
+“See the accident?” asked the policeman.
+
+“No, but the car passed me down the road, going faster’n forty. Going
+fifty, sixty.”
+
+“Come here and let’s have your name. Look out now. I want to get his
+name.”
+
+Some words of this conversation must have reached Wilson, swaying in
+the office door, for suddenly a new theme found voice among his
+grasping cries:
+
+“You don’t have to tell me what kind of car it was! I know what kind
+of car it was!”
+
+Watching Tom, I saw the wad of muscle back of his shoulder tighten
+under his coat. He walked quickly over to Wilson and, standing in
+front of him, seized him firmly by the upper arms.
+
+“You’ve got to pull yourself together,” he said with soothing
+gruffness.
+
+Wilson’s eyes fell upon Tom; he started up on his tiptoes and then
+would have collapsed to his knees had not Tom held him upright.
+
+“Listen,” said Tom, shaking him a little. “I just got here a minute
+ago, from New York. I was bringing you that coupé we’ve been talking
+about. That yellow car I was driving this afternoon wasn’t mine—do you
+hear? I haven’t seen it all afternoon.”
+
+Only the negro and I were near enough to hear what he said, but the
+policeman caught something in the tone and looked over with truculent
+eyes.
+
+“What’s all that?” he demanded.
+
+“I’m a friend of his.” Tom turned his head but kept his hands firm on
+Wilson’s body. “He says he knows the car that did it … It was a yellow
+car.”
+
+Some dim impulse moved the policeman to look suspiciously at Tom.
+
+“And what colour’s your car?”
+
+“It’s a blue car, a coupé.”
+
+“We’ve come straight from New York,” I said.
+
+Someone who had been driving a little behind us confirmed this, and
+the policeman turned away.
+
+“Now, if you’ll let me have that name again correct—”
+
+Picking up Wilson like a doll, Tom carried him into the office, set
+him down in a chair, and came back.
+
+“If somebody’ll come here and sit with him,” he snapped
+authoritatively. He watched while the two men standing closest glanced
+at each other and went unwillingly into the room. Then Tom shut the
+door on them and came down the single step, his eyes avoiding the
+table. As he passed close to me he whispered: “Let’s get out.”
+
+Self-consciously, with his authoritative arms breaking the way, we
+pushed through the still gathering crowd, passing a hurried doctor,
+case in hand, who had been sent for in wild hope half an hour ago.
+
+Tom drove slowly until we were beyond the bend—then his foot came down
+hard, and the coupé raced along through the night. In a little while I
+heard a low husky sob, and saw that the tears were overflowing down
+his face.
+
+“The God damned coward!” he whimpered. “He didn’t even stop his car.”
+
+------------------------------------------------------------------------
+
+The Buchanans’ house floated suddenly toward us through the dark
+rustling trees. Tom stopped beside the porch and looked up at the
+second floor, where two windows bloomed with light among the vines.
+
+“Daisy’s home,” he said. As we got out of the car he glanced at me and
+frowned slightly.
+
+“I ought to have dropped you in West Egg, Nick. There’s nothing we can
+do tonight.”
+
+A change had come over him, and he spoke gravely, and with decision.
+As we walked across the moonlight gravel to the porch he disposed of
+the situation in a few brisk phrases.
+
+“I’ll telephone for a taxi to take you home, and while you’re waiting
+you and Jordan better go in the kitchen and have them get you some
+supper—if you want any.” He opened the door. “Come in.”
+
+“No, thanks. But I’d be glad if you’d order me the taxi. I’ll wait
+outside.”
+
+Jordan put her hand on my arm.
+
+“Won’t you come in, Nick?”
+
+“No, thanks.”
+
+I was feeling a little sick and I wanted to be alone. But Jordan
+lingered for a moment more.
+
+“It’s only half-past nine,” she said.
+
+I’d be damned if I’d go in; I’d had enough of all of them for one day,
+and suddenly that included Jordan too. She must have seen something of
+this in my expression, for she turned abruptly away and ran up the
+porch steps into the house. I sat down for a few minutes with my head
+in my hands, until I heard the phone taken up inside and the butler’s
+voice calling a taxi. Then I walked slowly down the drive away from
+the house, intending to wait by the gate.
+
+I hadn’t gone twenty yards when I heard my name and Gatsby stepped
+from between two bushes into the path. I must have felt pretty weird
+by that time, because I could think of nothing except the luminosity
+of his pink suit under the moon.
+
+“What are you doing?” I inquired.
+
+“Just standing here, old sport.”
+
+Somehow, that seemed a despicable occupation. For all I knew he was
+going to rob the house in a moment; I wouldn’t have been surprised to
+see sinister faces, the faces of “Wolfshiem’s people,” behind him in
+the dark shrubbery.
+
+“Did you see any trouble on the road?” he asked after a minute.
+
+“Yes.”
+
+He hesitated.
+
+“Was she killed?”
+
+“Yes.”
+
+“I thought so; I told Daisy I thought so. It’s better that the shock
+should all come at once. She stood it pretty well.”
+
+He spoke as if Daisy’s reaction was the only thing that mattered.
+
+“I got to West Egg by a side road,” he went on, “and left the car in
+my garage. I don’t think anybody saw us, but of course I can’t be
+sure.”
+
+I disliked him so much by this time that I didn’t find it necessary to
+tell him he was wrong.
+
+“Who was the woman?” he inquired.
+
+“Her name was Wilson. Her husband owns the garage. How the devil did
+it happen?”
+
+“Well, I tried to swing the wheel—” He broke off, and suddenly I
+guessed at the truth.
+
+“Was Daisy driving?”
+
+“Yes,” he said after a moment, “but of course I’ll say I was. You see,
+when we left New York she was very nervous and she thought it would
+steady her to drive—and this woman rushed out at us just as we were
+passing a car coming the other way. It all happened in a minute, but
+it seemed to me that she wanted to speak to us, thought we were
+somebody she knew. Well, first Daisy turned away from the woman toward
+the other car, and then she lost her nerve and turned back. The second
+my hand reached the wheel I felt the shock—it must have killed her
+instantly.”
+
+“It ripped her open—”
+
+“Don’t tell me, old sport.” He winced. “Anyhow—Daisy stepped on it. I
+tried to make her stop, but she couldn’t, so I pulled on the emergency
+brake. Then she fell over into my lap and I drove on.
+
+“She’ll be all right tomorrow,” he said presently. “I’m just going to
+wait here and see if he tries to bother her about that unpleasantness
+this afternoon. She’s locked herself into her room, and if he tries
+any brutality she’s going to turn the light out and on again.”
+
+“He won’t touch her,” I said. “He’s not thinking about her.”
+
+“I don’t trust him, old sport.”
+
+“How long are you going to wait?”
+
+“All night, if necessary. Anyhow, till they all go to bed.”
+
+A new point of view occurred to me. Suppose Tom found out that Daisy
+had been driving. He might think he saw a connection in it—he might
+think anything. I looked at the house; there were two or three bright
+windows downstairs and the pink glow from Daisy’s room on the ground
+floor.
+
+“You wait here,” I said. “I’ll see if there’s any sign of a
+commotion.”
+
+I walked back along the border of the lawn, traversed the gravel
+softly, and tiptoed up the veranda steps. The drawing-room curtains
+were open, and I saw that the room was empty. Crossing the porch where
+we had dined that June night three months before, I came to a small
+rectangle of light which I guessed was the pantry window. The blind
+was drawn, but I found a rift at the sill.
+
+Daisy and Tom were sitting opposite each other at the kitchen table,
+with a plate of cold fried chicken between them, and two bottles of
+ale. He was talking intently across the table at her, and in his
+earnestness his hand had fallen upon and covered her own. Once in a
+while she looked up at him and nodded in agreement.
+
+They weren’t happy, and neither of them had touched the chicken or the
+ale—and yet they weren’t unhappy either. There was an unmistakable air
+of natural intimacy about the picture, and anybody would have said
+that they were conspiring together.
+
+As I tiptoed from the porch I heard my taxi feeling its way along the
+dark road toward the house. Gatsby was waiting where I had left him in
+the drive.
+
+“Is it all quiet up there?” he asked anxiously.
+
+“Yes, it’s all quiet.” I hesitated. “You’d better come home and get
+some sleep.”
+
+He shook his head.
+
+“I want to wait here till Daisy goes to bed. Good night, old sport.”
+
+He put his hands in his coat pockets and turned back eagerly to his
+scrutiny of the house, as though my presence marred the sacredness of
+the vigil. So I walked away and left him standing there in the
+moonlight—watching over nothing.
+
+
+                                 VIII
+
+I couldn’t sleep all night; a foghorn was groaning incessantly on the
+Sound, and I tossed half-sick between grotesque reality and savage,
+frightening dreams. Toward dawn I heard a taxi go up Gatsby’s drive,
+and immediately I jumped out of bed and began to dress—I felt that I
+had something to tell him, something to warn him about, and morning
+would be too late.
+
+Crossing his lawn, I saw that his front door was still open and he was
+leaning against a table in the hall, heavy with dejection or sleep.
+
+“Nothing happened,” he said wanly. “I waited, and about four o’clock
+she came to the window and stood there for a minute and then turned
+out the light.”
+
+His house had never seemed so enormous to me as it did that night when
+we hunted through the great rooms for cigarettes. We pushed aside
+curtains that were like pavilions, and felt over innumerable feet of
+dark wall for electric light switches—once I tumbled with a sort of
+splash upon the keys of a ghostly piano. There was an inexplicable
+amount of dust everywhere, and the rooms were musty, as though they
+hadn’t been aired for many days. I found the humidor on an unfamiliar
+table, with two stale, dry cigarettes inside. Throwing open the French
+windows of the drawing-room, we sat smoking out into the darkness.
+
+“You ought to go away,” I said. “It’s pretty certain they’ll trace
+your car.”
+
+“Go away now, old sport?”
+
+“Go to Atlantic City for a week, or up to Montreal.”
+
+He wouldn’t consider it. He couldn’t possibly leave Daisy until he
+knew what she was going to do. He was clutching at some last hope and
+I couldn’t bear to shake him free.
+
+It was this night that he told me the strange story of his youth with
+Dan Cody—told it to me because “Jay Gatsby” had broken up like glass
+against Tom’s hard malice, and the long secret extravaganza was played
+out. I think that he would have acknowledged anything now, without
+reserve, but he wanted to talk about Daisy.
+
+She was the first “nice” girl he had ever known. In various unrevealed
+capacities he had come in contact with such people, but always with
+indiscernible barbed wire between. He found her excitingly
+desirable. He went to her house, at first with other officers from
+Camp Taylor, then alone. It amazed him—he had never been in such a
+beautiful house before. But what gave it an air of breathless
+intensity, was that Daisy lived there—it was as casual a thing to her
+as his tent out at camp was to him. There was a ripe mystery about it,
+a hint of bedrooms upstairs more beautiful and cool than other
+bedrooms, of gay and radiant activities taking place through its
+corridors, and of romances that were not musty and laid away already
+in lavender but fresh and breathing and redolent of this year’s
+shining motorcars and of dances whose flowers were scarcely
+withered. It excited him, too, that many men had already loved
+Daisy—it increased her value in his eyes. He felt their presence all
+about the house, pervading the air with the shades and echoes of still
+vibrant emotions.
+
+But he knew that he was in Daisy’s house by a colossal
+accident. However glorious might be his future as Jay Gatsby, he was
+at present a penniless young man without a past, and at any moment the
+invisible cloak of his uniform might slip from his shoulders. So he
+made the most of his time. He took what he could get, ravenously and
+unscrupulously—eventually he took Daisy one still October night, took
+her because he had no real right to touch her hand.
+
+He might have despised himself, for he had certainly taken her under
+false pretences. I don’t mean that he had traded on his phantom
+millions, but he had deliberately given Daisy a sense of security; he
+let her believe that he was a person from much the same strata as
+herself—that he was fully able to take care of her. As a matter of
+fact, he had no such facilities—he had no comfortable family standing
+behind him, and he was liable at the whim of an impersonal government
+to be blown anywhere about the world.
+
+But he didn’t despise himself and it didn’t turn out as he had
+imagined. He had intended, probably, to take what he could and go—but
+now he found that he had committed himself to the following of a
+grail. He knew that Daisy was extraordinary, but he didn’t realize
+just how extraordinary a “nice” girl could be. She vanished into her
+rich house, into her rich, full life, leaving Gatsby—nothing. He felt
+married to her, that was all.
+
+When they met again, two days later, it was Gatsby who was breathless,
+who was, somehow, betrayed. Her porch was bright with the bought
+luxury of star-shine; the wicker of the settee squeaked fashionably as
+she turned toward him and he kissed her curious and lovely mouth. She
+had caught a cold, and it made her voice huskier and more charming
+than ever, and Gatsby was overwhelmingly aware of the youth and
+mystery that wealth imprisons and preserves, of the freshness of many
+clothes, and of Daisy, gleaming like silver, safe and proud above the
+hot struggles of the poor.
+
+------------------------------------------------------------------------
+
+“I can’t describe to you how surprised I was to find out I loved her,
+old sport. I even hoped for a while that she’d throw me over, but she
+didn’t, because she was in love with me too. She thought I knew a lot
+because I knew different things from her … Well, there I was, way off
+my ambitions, getting deeper in love every minute, and all of a sudden
+I didn’t care. What was the use of doing great things if I could have
+a better time telling her what I was going to do?”
+
+On the last afternoon before he went abroad, he sat with Daisy in his
+arms for a long, silent time. It was a cold fall day, with fire in the
+room and her cheeks flushed. Now and then she moved and he changed his
+arm a little, and once he kissed her dark shining hair. The afternoon
+had made them tranquil for a while, as if to give them a deep memory
+for the long parting the next day promised. They had never been closer
+in their month of love, nor communicated more profoundly one with
+another, than when she brushed silent lips against his coat’s shoulder
+or when he touched the end of her fingers, gently, as though she were
+asleep.
+
+------------------------------------------------------------------------
+
+He did extraordinarily well in the war. He was a captain before he
+went to the front, and following the Argonne battles he got his
+majority and the command of the divisional machine-guns. After the
+armistice he tried frantically to get home, but some complication or
+misunderstanding sent him to Oxford instead. He was worried now—there
+was a quality of nervous despair in Daisy’s letters. She didn’t see
+why he couldn’t come. She was feeling the pressure of the world
+outside, and she wanted to see him and feel his presence beside her
+and be reassured that she was doing the right thing after all.
+
+For Daisy was young and her artificial world was redolent of orchids
+and pleasant, cheerful snobbery and orchestras which set the rhythm of
+the year, summing up the sadness and suggestiveness of life in new
+tunes. All night the saxophones wailed the hopeless comment of the
+“Beale Street Blues” while a hundred pairs of golden and silver
+slippers shuffled the shining dust. At the grey tea hour there were
+always rooms that throbbed incessantly with this low, sweet fever,
+while fresh faces drifted here and there like rose petals blown by the
+sad horns around the floor.
+
+Through this twilight universe Daisy began to move again with the
+season; suddenly she was again keeping half a dozen dates a day with
+half a dozen men, and drowsing asleep at dawn with the beads and
+chiffon of an evening-dress tangled among dying orchids on the floor
+beside her bed. And all the time something within her was crying for a
+decision. She wanted her life shaped now, immediately—and the decision
+must be made by some force—of love, of money, of unquestionable
+practicality—that was close at hand.
+
+That force took shape in the middle of spring with the arrival of Tom
+Buchanan. There was a wholesome bulkiness about his person and his
+position, and Daisy was flattered. Doubtless there was a certain
+struggle and a certain relief. The letter reached Gatsby while he was
+still at Oxford.
+
+------------------------------------------------------------------------
+
+It was dawn now on Long Island and we went about opening the rest of
+the windows downstairs, filling the house with grey-turning,
+gold-turning light. The shadow of a tree fell abruptly across the dew
+and ghostly birds began to sing among the blue leaves. There was a
+slow, pleasant movement in the air, scarcely a wind, promising a cool,
+lovely day.
+
+“I don’t think she ever loved him.” Gatsby turned around from a window
+and looked at me challengingly. “You must remember, old sport, she was
+very excited this afternoon. He told her those things in a way that
+frightened her—that made it look as if I was some kind of cheap
+sharper. And the result was she hardly knew what she was saying.”
+
+He sat down gloomily.
+
+“Of course she might have loved him just for a minute, when they were
+first married—and loved me more even then, do you see?”
+
+Suddenly he came out with a curious remark.
+
+“In any case,” he said, “it was just personal.”
+
+What could you make of that, except to suspect some intensity in his
+conception of the affair that couldn’t be measured?
+
+He came back from France when Tom and Daisy were still on their
+wedding trip, and made a miserable but irresistible journey to
+Louisville on the last of his army pay. He stayed there a week,
+walking the streets where their footsteps had clicked together through
+the November night and revisiting the out-of-the-way places to which
+they had driven in her white car. Just as Daisy’s house had always
+seemed to him more mysterious and gay than other houses, so his idea
+of the city itself, even though she was gone from it, was pervaded
+with a melancholy beauty.
+
+He left feeling that if he had searched harder, he might have found
+her—that he was leaving her behind. The day-coach—he was penniless
+now—was hot. He went out to the open vestibule and sat down on a
+folding-chair, and the station slid away and the backs of unfamiliar
+buildings moved by. Then out into the spring fields, where a yellow
+trolley raced them for a minute with people in it who might once have
+seen the pale magic of her face along the casual street.
+
+The track curved and now it was going away from the sun, which, as it
+sank lower, seemed to spread itself in benediction over the vanishing
+city where she had drawn her breath. He stretched out his hand
+desperately as if to snatch only a wisp of air, to save a fragment of
+the spot that she had made lovely for him. But it was all going by too
+fast now for his blurred eyes and he knew that he had lost that part
+of it, the freshest and the best, forever.
+
+It was nine o’clock when we finished breakfast and went out on the
+porch. The night had made a sharp difference in the weather and there
+was an autumn flavour in the air. The gardener, the last one of
+Gatsby’s former servants, came to the foot of the steps.
+
+“I’m going to drain the pool today, Mr. Gatsby. Leaves’ll start
+falling pretty soon, and then there’s always trouble with the pipes.”
+
+“Don’t do it today,” Gatsby answered. He turned to me apologetically.
+“You know, old sport, I’ve never used that pool all summer?”
+
+I looked at my watch and stood up.
+
+“Twelve minutes to my train.”
+
+I didn’t want to go to the city. I wasn’t worth a decent stroke of
+work, but it was more than that—I didn’t want to leave Gatsby. I
+missed that train, and then another, before I could get myself away.
+
+“I’ll call you up,” I said finally.
+
+“Do, old sport.”
+
+“I’ll call you about noon.”
+
+We walked slowly down the steps.
+
+“I suppose Daisy’ll call too.” He looked at me anxiously, as if he
+hoped I’d corroborate this.
+
+“I suppose so.”
+
+“Well, goodbye.”
+
+We shook hands and I started away. Just before I reached the hedge I
+remembered something and turned around.
+
+“They’re a rotten crowd,” I shouted across the lawn. “You’re worth the
+whole damn bunch put together.”
+
+I’ve always been glad I said that. It was the only compliment I ever
+gave him, because I disapproved of him from beginning to end. First he
+nodded politely, and then his face broke into that radiant and
+understanding smile, as if we’d been in ecstatic cahoots on that fact
+all the time. His gorgeous pink rag of a suit made a bright spot of
+colour against the white steps, and I thought of the night when I
+first came to his ancestral home, three months before. The lawn and
+drive had been crowded with the faces of those who guessed at his
+corruption—and he had stood on those steps, concealing his
+incorruptible dream, as he waved them goodbye.
+
+I thanked him for his hospitality. We were always thanking him for
+that—I and the others.
+
+“Goodbye,” I called. “I enjoyed breakfast, Gatsby.”
+
+------------------------------------------------------------------------
+
+Up in the city, I tried for a while to list the quotations on an
+interminable amount of stock, then I fell asleep in my swivel-chair.
+Just before noon the phone woke me, and I started up with sweat
+breaking out on my forehead. It was Jordan Baker; she often called me
+up at this hour because the uncertainty of her own movements between
+hotels and clubs and private houses made her hard to find in any other
+way. Usually her voice came over the wire as something fresh and cool,
+as if a divot from a green golf-links had come sailing in at the
+office window, but this morning it seemed harsh and dry.
+
+“I’ve left Daisy’s house,” she said. “I’m at Hempstead, and I’m going
+down to Southampton this afternoon.”
+
+Probably it had been tactful to leave Daisy’s house, but the act
+annoyed me, and her next remark made me rigid.
+
+“You weren’t so nice to me last night.”
+
+“How could it have mattered then?”
+
+Silence for a moment. Then:
+
+“However—I want to see you.”
+
+“I want to see you, too.”
+
+“Suppose I don’t go to Southampton, and come into town this
+afternoon?”
+
+“No—I don’t think this afternoon.”
+
+“Very well.”
+
+“It’s impossible this afternoon. Various—”
+
+We talked like that for a while, and then abruptly we weren’t talking
+any longer. I don’t know which of us hung up with a sharp click, but I
+know I didn’t care. I couldn’t have talked to her across a tea-table
+that day if I never talked to her again in this world.
+
+I called Gatsby’s house a few minutes later, but the line was busy. I
+tried four times; finally an exasperated central told me the wire was
+being kept open for long distance from Detroit. Taking out my
+timetable, I drew a small circle around the three-fifty train. Then I
+leaned back in my chair and tried to think. It was just noon.
+
+------------------------------------------------------------------------
+
+When I passed the ash-heaps on the train that morning I had crossed
+deliberately to the other side of the car. I supposed there’d be a
+curious crowd around there all day with little boys searching for dark
+spots in the dust, and some garrulous man telling over and over what
+had happened, until it became less and less real even to him and he
+could tell it no longer, and Myrtle Wilson’s tragic achievement was
+forgotten. Now I want to go back a little and tell what happened at
+the garage after we left there the night before.
+
+They had difficulty in locating the sister, Catherine. She must have
+broken her rule against drinking that night, for when she arrived she
+was stupid with liquor and unable to understand that the ambulance had
+already gone to Flushing. When they convinced her of this, she
+immediately fainted, as if that was the intolerable part of the
+affair. Someone, kind or curious, took her in his car and drove her in
+the wake of her sister’s body.
+
+Until long after midnight a changing crowd lapped up against the front
+of the garage, while George Wilson rocked himself back and forth on
+the couch inside. For a while the door of the office was open, and
+everyone who came into the garage glanced irresistibly through it.
+Finally someone said it was a shame, and closed the door. Michaelis
+and several other men were with him; first, four or five men, later
+two or three men. Still later Michaelis had to ask the last stranger
+to wait there fifteen minutes longer, while he went back to his own
+place and made a pot of coffee. After that, he stayed there alone with
+Wilson until dawn.
+
+About three o’clock the quality of Wilson’s incoherent muttering
+changed—he grew quieter and began to talk about the yellow car. He
+announced that he had a way of finding out whom the yellow car
+belonged to, and then he blurted out that a couple of months ago his
+wife had come from the city with her face bruised and her nose
+swollen.
+
+But when he heard himself say this, he flinched and began to cry “Oh,
+my God!” again in his groaning voice. Michaelis made a clumsy attempt
+to distract him.
+
+“How long have you been married, George? Come on there, try and sit
+still a minute, and answer my question. How long have you been
+married?”
+
+“Twelve years.”
+
+“Ever had any children? Come on, George, sit still—I asked you a
+question. Did you ever have any children?”
+
+The hard brown beetles kept thudding against the dull light, and
+whenever Michaelis heard a car go tearing along the road outside it
+sounded to him like the car that hadn’t stopped a few hours before.
+He didn’t like to go into the garage, because the work bench was
+stained where the body had been lying, so he moved uncomfortably
+around the office—he knew every object in it before morning—and from
+time to time sat down beside Wilson trying to keep him more quiet.
+
+“Have you got a church you go to sometimes, George? Maybe even if you
+haven’t been there for a long time? Maybe I could call up the church
+and get a priest to come over and he could talk to you, see?”
+
+“Don’t belong to any.”
+
+“You ought to have a church, George, for times like this. You must
+have gone to church once. Didn’t you get married in a church? Listen,
+George, listen to me. Didn’t you get married in a church?”
+
+“That was a long time ago.”
+
+The effort of answering broke the rhythm of his rocking—for a moment
+he was silent. Then the same half-knowing, half-bewildered look came
+back into his faded eyes.
+
+“Look in the drawer there,” he said, pointing at the desk.
+
+“Which drawer?”
+
+“That drawer—that one.”
+
+Michaelis opened the drawer nearest his hand. There was nothing in it
+but a small, expensive dog-leash, made of leather and braided
+silver. It was apparently new.
+
+“This?” he inquired, holding it up.
+
+Wilson stared and nodded.
+
+“I found it yesterday afternoon. She tried to tell me about it, but I
+knew it was something funny.”
+
+“You mean your wife bought it?”
+
+“She had it wrapped in tissue paper on her bureau.”
+
+Michaelis didn’t see anything odd in that, and he gave Wilson a dozen
+reasons why his wife might have bought the dog-leash. But conceivably
+Wilson had heard some of these same explanations before, from Myrtle,
+because he began saying “Oh, my God!” again in a whisper—his comforter
+left several explanations in the air.
+
+“Then he killed her,” said Wilson. His mouth dropped open suddenly.
+
+“Who did?”
+
+“I have a way of finding out.”
+
+“You’re morbid, George,” said his friend. “This has been a strain to
+you and you don’t know what you’re saying. You’d better try and sit
+quiet till morning.”
+
+“He murdered her.”
+
+“It was an accident, George.”
+
+Wilson shook his head. His eyes narrowed and his mouth widened
+slightly with the ghost of a superior “Hm!”
+
+“I know,” he said definitely. “I’m one of these trusting fellas and I
+don’t think any harm to nobody, but when I get to know a thing I know
+it. It was the man in that car. She ran out to speak to him and he
+wouldn’t stop.”
+
+Michaelis had seen this too, but it hadn’t occurred to him that there
+was any special significance in it. He believed that Mrs. Wilson had
+been running away from her husband, rather than trying to stop any
+particular car.
+
+“How could she of been like that?”
+
+“She’s a deep one,” said Wilson, as if that answered the question.
+“Ah-h-h—”
+
+He began to rock again, and Michaelis stood twisting the leash in his
+hand.
+
+“Maybe you got some friend that I could telephone for, George?”
+
+This was a forlorn hope—he was almost sure that Wilson had no friend:
+there was not enough of him for his wife. He was glad a little later
+when he noticed a change in the room, a blue quickening by the window,
+and realized that dawn wasn’t far off. About five o’clock it was blue
+enough outside to snap off the light.
+
+Wilson’s glazed eyes turned out to the ash-heaps, where small grey
+clouds took on fantastic shapes and scurried here and there in the
+faint dawn wind.
+
+“I spoke to her,” he muttered, after a long silence. “I told her she
+might fool me but she couldn’t fool God. I took her to the
+window”—with an effort he got up and walked to the rear window and
+leaned with his face pressed against it—“and I said ‘God knows what
+you’ve been doing, everything you’ve been doing. You may fool me, but
+you can’t fool God!’ ”
+
+Standing behind him, Michaelis saw with a shock that he was looking at
+the eyes of Doctor T. J. Eckleburg, which had just emerged, pale and
+enormous, from the dissolving night.
+
+“God sees everything,” repeated Wilson.
+
+“That’s an advertisement,” Michaelis assured him. Something made him
+turn away from the window and look back into the room. But Wilson
+stood there a long time, his face close to the window pane, nodding
+into the twilight.
+
+------------------------------------------------------------------------
+
+By six o’clock Michaelis was worn out, and grateful for the sound of a
+car stopping outside. It was one of the watchers of the night before
+who had promised to come back, so he cooked breakfast for three, which
+he and the other man ate together. Wilson was quieter now, and
+Michaelis went home to sleep; when he awoke four hours later and
+hurried back to the garage, Wilson was gone.
+
+His movements—he was on foot all the time—were afterward traced to
+Port Roosevelt and then to Gad’s Hill, where he bought a sandwich that
+he didn’t eat, and a cup of coffee. He must have been tired and
+walking slowly, for he didn’t reach Gad’s Hill until noon. Thus far
+there was no difficulty in accounting for his time—there were boys who
+had seen a man “acting sort of crazy,” and motorists at whom he stared
+oddly from the side of the road. Then for three hours he disappeared
+from view. The police, on the strength of what he said to Michaelis,
+that he “had a way of finding out,” supposed that he spent that time
+going from garage to garage thereabout, inquiring for a yellow car. On
+the other hand, no garage man who had seen him ever came forward, and
+perhaps he had an easier, surer way of finding out what he wanted to
+know. By half-past two he was in West Egg, where he asked someone the
+way to Gatsby’s house. So by that time he knew Gatsby’s name.
+
+------------------------------------------------------------------------
+
+At two o’clock Gatsby put on his bathing-suit and left word with the
+butler that if anyone phoned word was to be brought to him at the
+pool. He stopped at the garage for a pneumatic mattress that had
+amused his guests during the summer, and the chauffeur helped him to
+pump it up. Then he gave instructions that the open car wasn’t to be
+taken out under any circumstances—and this was strange, because the
+front right fender needed repair.
+
+Gatsby shouldered the mattress and started for the pool. Once he
+stopped and shifted it a little, and the chauffeur asked him if he
+needed help, but he shook his head and in a moment disappeared among
+the yellowing trees.
+
+No telephone message arrived, but the butler went without his sleep
+and waited for it until four o’clock—until long after there was anyone
+to give it to if it came. I have an idea that Gatsby himself didn’t
+believe it would come, and perhaps he no longer cared. If that was
+true he must have felt that he had lost the old warm world, paid a
+high price for living too long with a single dream. He must have
+looked up at an unfamiliar sky through frightening leaves and shivered
+as he found what a grotesque thing a rose is and how raw the sunlight
+was upon the scarcely created grass. A new world, material without
+being real, where poor ghosts, breathing dreams like air, drifted
+fortuitously about … like that ashen, fantastic figure gliding toward
+him through the amorphous trees.
+
+The chauffeur—he was one of Wolfshiem’s protégés—heard the
+shots—afterwards he could only say that he hadn’t thought anything
+much about them. I drove from the station directly to Gatsby’s house
+and my rushing anxiously up the front steps was the first thing that
+alarmed anyone. But they knew then, I firmly believe. With scarcely a
+word said, four of us, the chauffeur, butler, gardener, and I hurried
+down to the pool.
+
+There was a faint, barely perceptible movement of the water as the
+fresh flow from one end urged its way toward the drain at the other.
+With little ripples that were hardly the shadows of waves, the laden
+mattress moved irregularly down the pool. A small gust of wind that
+scarcely corrugated the surface was enough to disturb its accidental
+course with its accidental burden. The touch of a cluster of leaves
+revolved it slowly, tracing, like the leg of transit, a thin red
+circle in the water.
+
+It was after we started with Gatsby toward the house that the gardener
+saw Wilson’s body a little way off in the grass, and the holocaust was
+complete.
+
+
+                                  IX
+
+After two years I remember the rest of that day, and that night and
+the next day, only as an endless drill of police and photographers and
+newspaper men in and out of Gatsby’s front door. A rope stretched
+across the main gate and a policeman by it kept out the curious, but
+little boys soon discovered that they could enter through my yard, and
+there were always a few of them clustered open-mouthed about the
+pool. Someone with a positive manner, perhaps a detective, used the
+expression “madman” as he bent over Wilson’s body that afternoon, and
+the adventitious authority of his voice set the key for the newspaper
+reports next morning.
+
+Most of those reports were a nightmare—grotesque, circumstantial,
+eager, and untrue. When Michaelis’s testimony at the inquest brought
+to light Wilson’s suspicions of his wife I thought the whole tale
+would shortly be served up in racy pasquinade—but Catherine, who might
+have said anything, didn’t say a word. She showed a surprising amount
+of character about it too—looked at the coroner with determined eyes
+under that corrected brow of hers, and swore that her sister had never
+seen Gatsby, that her sister was completely happy with her husband,
+that her sister had been into no mischief whatever. She convinced
+herself of it, and cried into her handkerchief, as if the very
+suggestion was more than she could endure. So Wilson was reduced to a
+man “deranged by grief” in order that the case might remain in its
+simplest form. And it rested there.
+
+But all this part of it seemed remote and unessential. I found myself
+on Gatsby’s side, and alone. From the moment I telephoned news of the
+catastrophe to West Egg village, every surmise about him, and every
+practical question, was referred to me. At first I was surprised and
+confused; then, as he lay in his house and didn’t move or breathe or
+speak, hour upon hour, it grew upon me that I was responsible, because
+no one else was interested—interested, I mean, with that intense
+personal interest to which everyone has some vague right at the end.
+
+I called up Daisy half an hour after we found him, called her
+instinctively and without hesitation. But she and Tom had gone away
+early that afternoon, and taken baggage with them.
+
+“Left no address?”
+
+“No.”
+
+“Say when they’d be back?”
+
+“No.”
+
+“Any idea where they are? How I could reach them?”
+
+“I don’t know. Can’t say.”
+
+I wanted to get somebody for him. I wanted to go into the room where
+he lay and reassure him: “I’ll get somebody for you, Gatsby. Don’t
+worry. Just trust me and I’ll get somebody for you—”
+
+Meyer Wolfshiem’s name wasn’t in the phone book. The butler gave me
+his office address on Broadway, and I called Information, but by the
+time I had the number it was long after five, and no one answered the
+phone.
+
+“Will you ring again?”
+
+“I’ve rung three times.”
+
+“It’s very important.”
+
+“Sorry. I’m afraid no one’s there.”
+
+I went back to the drawing-room and thought for an instant that they
+were chance visitors, all these official people who suddenly filled
+it. But, though they drew back the sheet and looked at Gatsby with
+shocked eyes, his protest continued in my brain:
+
+“Look here, old sport, you’ve got to get somebody for me. You’ve got
+to try hard. I can’t go through this alone.”
+
+Someone started to ask me questions, but I broke away and going
+upstairs looked hastily through the unlocked parts of his desk—he’d
+never told me definitely that his parents were dead. But there was
+nothing—only the picture of Dan Cody, a token of forgotten violence,
+staring down from the wall.
+
+Next morning I sent the butler to New York with a letter to Wolfshiem,
+which asked for information and urged him to come out on the next
+train. That request seemed superfluous when I wrote it. I was sure
+he’d start when he saw the newspapers, just as I was sure there’d be a
+wire from Daisy before noon—but neither a wire nor Mr. Wolfshiem
+arrived; no one arrived except more police and photographers and
+newspaper men. When the butler brought back Wolfshiem’s answer I began
+to have a feeling of defiance, of scornful solidarity between Gatsby
+and me against them all.
+
+ Dear Mr. Carraway. This has been one of the most terrible shocks of
+ my life to me I hardly can believe it that it is true at all. Such a
+ mad act as that man did should make us all think. I cannot come down
+ now as I am tied up in some very important business and cannot get
+ mixed up in this thing now. If there is anything I can do a little
+ later let me know in a letter by Edgar. I hardly know where I am when
+ I hear about a thing like this and am completely knocked down and
+ out.
+
+                               Yours truly
+
+                             Meyer Wolfshiem
+
+and then hasty addenda beneath:
+
+ Let me know about the funeral etc do not know his family at all.
+
+When the phone rang that afternoon and Long Distance said Chicago was
+calling I thought this would be Daisy at last. But the connection came
+through as a man’s voice, very thin and far away.
+
+“This is Slagle speaking …”
+
+“Yes?” The name was unfamiliar.
+
+“Hell of a note, isn’t it? Get my wire?”
+
+“There haven’t been any wires.”
+
+“Young Parke’s in trouble,” he said rapidly. “They picked him up when
+he handed the bonds over the counter. They got a circular from New
+York giving ’em the numbers just five minutes before. What d’you know
+about that, hey? You never can tell in these hick towns—”
+
+“Hello!” I interrupted breathlessly. “Look here—this isn’t Mr.
+Gatsby. Mr. Gatsby’s dead.”
+
+There was a long silence on the other end of the wire, followed by an
+exclamation … then a quick squawk as the connection was broken.
+
+------------------------------------------------------------------------
+
+I think it was on the third day that a telegram signed Henry C. Gatz
+arrived from a town in Minnesota. It said only that the sender was
+leaving immediately and to postpone the funeral until he came.
+
+It was Gatsby’s father, a solemn old man, very helpless and dismayed,
+bundled up in a long cheap ulster against the warm September day. His
+eyes leaked continuously with excitement, and when I took the bag and
+umbrella from his hands he began to pull so incessantly at his sparse
+grey beard that I had difficulty in getting off his coat. He was on
+the point of collapse, so I took him into the music-room and made him
+sit down while I sent for something to eat. But he wouldn’t eat, and
+the glass of milk spilled from his trembling hand.
+
+“I saw it in the Chicago newspaper,” he said. “It was all in the
+Chicago newspaper. I started right away.”
+
+“I didn’t know how to reach you.”
+
+His eyes, seeing nothing, moved ceaselessly about the room.
+
+“It was a madman,” he said. “He must have been mad.”
+
+“Wouldn’t you like some coffee?” I urged him.
+
+“I don’t want anything. I’m all right now, Mr.—”
+
+“Carraway.”
+
+“Well, I’m all right now. Where have they got Jimmy?”
+
+I took him into the drawing-room, where his son lay, and left him
+there. Some little boys had come up on the steps and were looking into
+the hall; when I told them who had arrived, they went reluctantly
+away.
+
+After a little while Mr. Gatz opened the door and came out, his mouth
+ajar, his face flushed slightly, his eyes leaking isolated and
+unpunctual tears. He had reached an age where death no longer has the
+quality of ghastly surprise, and when he looked around him now for the
+first time and saw the height and splendour of the hall and the great
+rooms opening out from it into other rooms, his grief began to be
+mixed with an awed pride. I helped him to a bedroom upstairs; while he
+took off his coat and vest I told him that all arrangements had been
+deferred until he came.
+
+“I didn’t know what you’d want, Mr. Gatsby—”
+
+“Gatz is my name.”
+
+“—Mr. Gatz. I thought you might want to take the body West.”
+
+He shook his head.
+
+“Jimmy always liked it better down East. He rose up to his position in
+the East. Were you a friend of my boy’s, Mr.—?”
+
+“We were close friends.”
+
+“He had a big future before him, you know. He was only a young man,
+but he had a lot of brain power here.”
+
+He touched his head impressively, and I nodded.
+
+“If he’d of lived, he’d of been a great man. A man like James J.
+Hill. He’d of helped build up the country.”
+
+“That’s true,” I said, uncomfortably.
+
+He fumbled at the embroidered coverlet, trying to take it from the
+bed, and lay down stiffly—was instantly asleep.
+
+That night an obviously frightened person called up, and demanded to
+know who I was before he would give his name.
+
+“This is Mr. Carraway,” I said.
+
+“Oh!” He sounded relieved. “This is Klipspringer.”
+
+I was relieved too, for that seemed to promise another friend at
+Gatsby’s grave. I didn’t want it to be in the papers and draw a
+sightseeing crowd, so I’d been calling up a few people myself. They
+were hard to find.
+
+“The funeral’s tomorrow,” I said. “Three o’clock, here at the house.
+I wish you’d tell anybody who’d be interested.”
+
+“Oh, I will,” he broke out hastily. “Of course I’m not likely to see
+anybody, but if I do.”
+
+His tone made me suspicious.
+
+“Of course you’ll be there yourself.”
+
+“Well, I’ll certainly try. What I called up about is—”
+
+“Wait a minute,” I interrupted. “How about saying you’ll come?”
+
+“Well, the fact is—the truth of the matter is that I’m staying with
+some people up here in Greenwich, and they rather expect me to be with
+them tomorrow. In fact, there’s a sort of picnic or something. Of
+course I’ll do my best to get away.”
+
+I ejaculated an unrestrained “Huh!” and he must have heard me, for he
+went on nervously:
+
+“What I called up about was a pair of shoes I left there. I wonder if
+it’d be too much trouble to have the butler send them on. You see,
+they’re tennis shoes, and I’m sort of helpless without them. My
+address is care of B. F.—”
+
+I didn’t hear the rest of the name, because I hung up the receiver.
+
+After that I felt a certain shame for Gatsby—one gentleman to whom I
+telephoned implied that he had got what he deserved. However, that was
+my fault, for he was one of those who used to sneer most bitterly at
+Gatsby on the courage of Gatsby’s liquor, and I should have known
+better than to call him.
+
+The morning of the funeral I went up to New York to see Meyer
+Wolfshiem; I couldn’t seem to reach him any other way. The door that I
+pushed open, on the advice of an elevator boy, was marked “The
+Swastika Holding Company,” and at first there didn’t seem to be anyone
+inside. But when I’d shouted “hello” several times in vain, an
+argument broke out behind a partition, and presently a lovely Jewess
+appeared at an interior door and scrutinized me with black hostile
+eyes.
+
+“Nobody’s in,” she said. “Mr. Wolfshiem’s gone to Chicago.”
+
+The first part of this was obviously untrue, for someone had begun to
+whistle “The Rosary,” tunelessly, inside.
+
+“Please say that Mr. Carraway wants to see him.”
+
+“I can’t get him back from Chicago, can I?”
+
+At this moment a voice, unmistakably Wolfshiem’s, called “Stella!”
+from the other side of the door.
+
+“Leave your name on the desk,” she said quickly. “I’ll give it to him
+when he gets back.”
+
+“But I know he’s there.”
+
+She took a step toward me and began to slide her hands indignantly up
+and down her hips.
+
+“You young men think you can force your way in here any time,” she
+scolded. “We’re getting sickantired of it. When I say he’s in Chicago,
+he’s in Chicago.”
+
+I mentioned Gatsby.
+
+“Oh-h!” She looked at me over again. “Will you just—What was your
+name?”
+
+She vanished. In a moment Meyer Wolfshiem stood solemnly in the
+doorway, holding out both hands. He drew me into his office, remarking
+in a reverent voice that it was a sad time for all of us, and offered
+me a cigar.
+
+“My memory goes back to when first I met him,” he said. “A young major
+just out of the army and covered over with medals he got in the war.
+He was so hard up he had to keep on wearing his uniform because he
+couldn’t buy some regular clothes. First time I saw him was when he
+came into Winebrenner’s poolroom at Forty-third Street and asked for a
+job. He hadn’t eat anything for a couple of days. ‘Come on have some
+lunch with me,’ I said. He ate more than four dollars’ worth of food
+in half an hour.”
+
+“Did you start him in business?” I inquired.
+
+“Start him! I made him.”
+
+“Oh.”
+
+“I raised him up out of nothing, right out of the gutter. I saw right
+away he was a fine-appearing, gentlemanly young man, and when he told
+me he was at Oggsford I knew I could use him good. I got him to join
+the American Legion and he used to stand high there. Right off he did
+some work for a client of mine up to Albany. We were so thick like
+that in everything”—he held up two bulbous fingers—“always together.”
+
+I wondered if this partnership had included the World’s Series
+transaction in 1919.
+
+“Now he’s dead,” I said after a moment. “You were his closest friend,
+so I know you’ll want to come to his funeral this afternoon.”
+
+“I’d like to come.”
+
+“Well, come then.”
+
+The hair in his nostrils quivered slightly, and as he shook his head
+his eyes filled with tears.
+
+“I can’t do it—I can’t get mixed up in it,” he said.
+
+“There’s nothing to get mixed up in. It’s all over now.”
+
+“When a man gets killed I never like to get mixed up in it in any
+way. I keep out. When I was a young man it was different—if a friend
+of mine died, no matter how, I stuck with them to the end. You may
+think that’s sentimental, but I mean it—to the bitter end.”
+
+I saw that for some reason of his own he was determined not to come,
+so I stood up.
+
+“Are you a college man?” he inquired suddenly.
+
+For a moment I thought he was going to suggest a “gonnegtion,” but he
+only nodded and shook my hand.
+
+“Let us learn to show our friendship for a man when he is alive and
+not after he is dead,” he suggested. “After that my own rule is to let
+everything alone.”
+
+When I left his office the sky had turned dark and I got back to West
+Egg in a drizzle. After changing my clothes I went next door and found
+Mr. Gatz walking up and down excitedly in the hall. His pride in his
+son and in his son’s possessions was continually increasing and now he
+had something to show me.
+
+“Jimmy sent me this picture.” He took out his wallet with trembling
+fingers. “Look there.”
+
+It was a photograph of the house, cracked in the corners and dirty
+with many hands. He pointed out every detail to me eagerly. “Look
+there!” and then sought admiration from my eyes. He had shown it so
+often that I think it was more real to him now than the house itself.
+
+“Jimmy sent it to me. I think it’s a very pretty picture. It shows up
+well.”
+
+“Very well. Had you seen him lately?”
+
+“He come out to see me two years ago and bought me the house I live in
+now. Of course we was broke up when he run off from home, but I see
+now there was a reason for it. He knew he had a big future in front of
+him. And ever since he made a success he was very generous with me.”
+
+He seemed reluctant to put away the picture, held it for another
+minute, lingeringly, before my eyes. Then he returned the wallet and
+pulled from his pocket a ragged old copy of a book called Hopalong
+Cassidy.
+
+“Look here, this is a book he had when he was a boy. It just shows
+you.”
+
+He opened it at the back cover and turned it around for me to see. On
+the last flyleaf was printed the word schedule, and the date September
+12, 1906. And underneath:
+
+    Rise from bed                                  6:00      a.m.
+    Dumbell exercise and wall-scaling              6:15-6:30 ”
+    Study electricity, etc.                        7:15-8:15 ”
+    Work                                           8:30-4:30 p.m.
+    Baseball and sports                            4:30-5:00 ”
+    Practise elocution, poise and how to attain it 5:00-6:00 ”
+    Study needed inventions                        7:00-9:00 ”
+
+               General Resolves
+
+  * No wasting time at Shafters or [a name, indecipherable]
+
+  * No more smokeing or chewing.
+
+  * Bath every other day
+
+  * Read one improving book or magazine per week
+
+  * Save $5.00 [crossed out] $3.00 per week
+
+  * Be better to parents
+
+“I came across this book by accident,” said the old man. “It just
+shows you, don’t it?”
+
+“It just shows you.”
+
+“Jimmy was bound to get ahead. He always had some resolves like this
+or something. Do you notice what he’s got about improving his mind? He
+was always great for that. He told me I et like a hog once, and I beat
+him for it.”
+
+He was reluctant to close the book, reading each item aloud and then
+looking eagerly at me. I think he rather expected me to copy down the
+list for my own use.
+
+A little before three the Lutheran minister arrived from Flushing, and
+I began to look involuntarily out the windows for other cars. So did
+Gatsby’s father. And as the time passed and the servants came in and
+stood waiting in the hall, his eyes began to blink anxiously, and he
+spoke of the rain in a worried, uncertain way. The minister glanced
+several times at his watch, so I took him aside and asked him to wait
+for half an hour. But it wasn’t any use. Nobody came.
+
+------------------------------------------------------------------------
+
+About five o’clock our procession of three cars reached the cemetery
+and stopped in a thick drizzle beside the gate—first a motor hearse,
+horribly black and wet, then Mr. Gatz and the minister and me in the
+limousine, and a little later four or five servants and the postman
+from West Egg, in Gatsby’s station wagon, all wet to the skin. As we
+started through the gate into the cemetery I heard a car stop and then
+the sound of someone splashing after us over the soggy ground. I
+looked around. It was the man with owl-eyed glasses whom I had found
+marvelling over Gatsby’s books in the library one night three months
+before.
+
+I’d never seen him since then. I don’t know how he knew about the
+funeral, or even his name. The rain poured down his thick glasses, and
+he took them off and wiped them to see the protecting canvas unrolled
+from Gatsby’s grave.
+
+I tried to think about Gatsby then for a moment, but he was already
+too far away, and I could only remember, without resentment, that
+Daisy hadn’t sent a message or a flower. Dimly I heard someone murmur
+“Blessed are the dead that the rain falls on,” and then the owl-eyed
+man said “Amen to that,” in a brave voice.
+
+We straggled down quickly through the rain to the cars. Owl-eyes spoke
+to me by the gate.
+
+“I couldn’t get to the house,” he remarked.
+
+“Neither could anybody else.”
+
+“Go on!” He started. “Why, my God! they used to go there by the
+hundreds.”
+
+He took off his glasses and wiped them again, outside and in.
+
+“The poor son-of-a-bitch,” he said.
+
+------------------------------------------------------------------------
+
+One of my most vivid memories is of coming back West from prep school
+and later from college at Christmas time. Those who went farther than
+Chicago would gather in the old dim Union Station at six o’clock of a
+December evening, with a few Chicago friends, already caught up into
+their own holiday gaieties, to bid them a hasty goodbye. I remember
+the fur coats of the girls returning from Miss This-or-That’s and the
+chatter of frozen breath and the hands waving overhead as we caught
+sight of old acquaintances, and the matchings of invitations: “Are you
+going to the Ordways’? the Herseys’? the Schultzes’?” and the long
+green tickets clasped tight in our gloved hands. And last the murky
+yellow cars of the Chicago, Milwaukee and St. Paul railroad looking
+cheerful as Christmas itself on the tracks beside the gate.
+
+When we pulled out into the winter night and the real snow, our snow,
+began to stretch out beside us and twinkle against the windows, and
+the dim lights of small Wisconsin stations moved by, a sharp wild
+brace came suddenly into the air. We drew in deep breaths of it as we
+walked back from dinner through the cold vestibules, unutterably aware
+of our identity with this country for one strange hour, before we
+melted indistinguishably into it again.
+
+That’s my Middle West—not the wheat or the prairies or the lost Swede
+towns, but the thrilling returning trains of my youth, and the street
+lamps and sleigh bells in the frosty dark and the shadows of holly
+wreaths thrown by lighted windows on the snow. I am part of that, a
+little solemn with the feel of those long winters, a little complacent
+from growing up in the Carraway house in a city where dwellings are
+still called through decades by a family’s name. I see now that this
+has been a story of the West, after all—Tom and Gatsby, Daisy and
+Jordan and I, were all Westerners, and perhaps we possessed some
+deficiency in common which made us subtly unadaptable to Eastern life.
+
+Even when the East excited me most, even when I was most keenly aware
+of its superiority to the bored, sprawling, swollen towns beyond the
+Ohio, with their interminable inquisitions which spared only the
+children and the very old—even then it had always for me a quality of
+distortion. West Egg, especially, still figures in my more fantastic
+dreams. I see it as a night scene by El Greco: a hundred houses, at
+once conventional and grotesque, crouching under a sullen, overhanging
+sky and a lustreless moon. In the foreground four solemn men in dress
+suits are walking along the sidewalk with a stretcher on which lies a
+drunken woman in a white evening dress. Her hand, which dangles over
+the side, sparkles cold with jewels. Gravely the men turn in at a
+house—the wrong house. But no one knows the woman’s name, and no one
+cares.
+
+After Gatsby’s death the East was haunted for me like that, distorted
+beyond my eyes’ power of correction. So when the blue smoke of brittle
+leaves was in the air and the wind blew the wet laundry stiff on the
+line I decided to come back home.
+
+There was one thing to be done before I left, an awkward, unpleasant
+thing that perhaps had better have been let alone. But I wanted to
+leave things in order and not just trust that obliging and indifferent
+sea to sweep my refuse away. I saw Jordan Baker and talked over and
+around what had happened to us together, and what had happened
+afterward to me, and she lay perfectly still, listening, in a big
+chair.
+
+She was dressed to play golf, and I remember thinking she looked like
+a good illustration, her chin raised a little jauntily, her hair the
+colour of an autumn leaf, her face the same brown tint as the
+fingerless glove on her knee. When I had finished she told me without
+comment that she was engaged to another man. I doubted that, though
+there were several she could have married at a nod of her head, but I
+pretended to be surprised. For just a minute I wondered if I wasn’t
+making a mistake, then I thought it all over again quickly and got up
+to say goodbye.
+
+“Nevertheless you did throw me over,” said Jordan suddenly. “You threw
+me over on the telephone. I don’t give a damn about you now, but it
+was a new experience for me, and I felt a little dizzy for a while.”
+
+We shook hands.
+
+“Oh, and do you remember”—she added—“a conversation we had once about
+driving a car?”
+
+“Why—not exactly.”
+
+“You said a bad driver was only safe until she met another bad driver?
+Well, I met another bad driver, didn’t I? I mean it was careless of me
+to make such a wrong guess. I thought you were rather an honest,
+straightforward person. I thought it was your secret pride.”
+
+“I’m thirty,” I said. “I’m five years too old to lie to myself and
+call it honour.”
+
+She didn’t answer. Angry, and half in love with her, and tremendously
+sorry, I turned away.
+
+------------------------------------------------------------------------
+
+One afternoon late in October I saw Tom Buchanan. He was walking ahead
+of me along Fifth Avenue in his alert, aggressive way, his hands out a
+little from his body as if to fight off interference, his head moving
+sharply here and there, adapting itself to his restless eyes. Just as
+I slowed up to avoid overtaking him he stopped and began frowning into
+the windows of a jewellery store. Suddenly he saw me and walked back,
+holding out his hand.
+
+“What’s the matter, Nick? Do you object to shaking hands with me?”
+
+“Yes. You know what I think of you.”
+
+“You’re crazy, Nick,” he said quickly. “Crazy as hell. I don’t know
+what’s the matter with you.”
+
+“Tom,” I inquired, “what did you say to Wilson that afternoon?”
+
+He stared at me without a word, and I knew I had guessed right about
+those missing hours. I started to turn away, but he took a step after
+me and grabbed my arm.
+
+“I told him the truth,” he said. “He came to the door while we were
+getting ready to leave, and when I sent down word that we weren’t in
+he tried to force his way upstairs. He was crazy enough to kill me if
+I hadn’t told him who owned the car. His hand was on a revolver in his
+pocket every minute he was in the house—” He broke off defiantly.
+“What if I did tell him? That fellow had it coming to him. He threw
+dust into your eyes just like he did in Daisy’s, but he was a tough
+one. He ran over Myrtle like you’d run over a dog and never even
+stopped his car.”
+
+There was nothing I could say, except the one unutterable fact that it
+wasn’t true.
+
+“And if you think I didn’t have my share of suffering—look here, when
+I went to give up that flat and saw that damn box of dog biscuits
+sitting there on the sideboard, I sat down and cried like a baby. By
+God it was awful—”
+
+I couldn’t forgive him or like him, but I saw that what he had done
+was, to him, entirely justified. It was all very careless and
+confused. They were careless people, Tom and Daisy—they smashed up
+things and creatures and then retreated back into their money or their
+vast carelessness, or whatever it was that kept them together, and let
+other people clean up the mess they had made …
+
+I shook hands with him; it seemed silly not to, for I felt suddenly as
+though I were talking to a child. Then he went into the jewellery
+store to buy a pearl necklace—or perhaps only a pair of cuff
+buttons—rid of my provincial squeamishness forever.
+
+------------------------------------------------------------------------
+
+Gatsby’s house was still empty when I left—the grass on his lawn had
+grown as long as mine. One of the taxi drivers in the village never
+took a fare past the entrance gate without stopping for a minute and
+pointing inside; perhaps it was he who drove Daisy and Gatsby over to
+East Egg the night of the accident, and perhaps he had made a story
+about it all his own. I didn’t want to hear it and I avoided him when
+I got off the train.
+
+I spent my Saturday nights in New York because those gleaming,
+dazzling parties of his were with me so vividly that I could still
+hear the music and the laughter, faint and incessant, from his garden,
+and the cars going up and down his drive. One night I did hear a
+material car there, and saw its lights stop at his front steps. But I
+didn’t investigate. Probably it was some final guest who had been away
+at the ends of the earth and didn’t know that the party was over.
+
+On the last night, with my trunk packed and my car sold to the grocer,
+I went over and looked at that huge incoherent failure of a house once
+more. On the white steps an obscene word, scrawled by some boy with a
+piece of brick, stood out clearly in the moonlight, and I erased it,
+drawing my shoe raspingly along the stone. Then I wandered down to the
+beach and sprawled out on the sand.
+
+Most of the big shore places were closed now and there were hardly any
+lights except the shadowy, moving glow of a ferryboat across the
+Sound. And as the moon rose higher the inessential houses began to
+melt away until gradually I became aware of the old island here that
+flowered once for Dutch sailors’ eyes—a fresh, green breast of the new
+world. Its vanished trees, the trees that had made way for Gatsby’s
+house, had once pandered in whispers to the last and greatest of all
+human dreams; for a transitory enchanted moment man must have held his
+breath in the presence of this continent, compelled into an aesthetic
+contemplation he neither understood nor desired, face to face for the
+last time in history with something commensurate to his capacity for
+wonder.
+
+And as I sat there brooding on the old, unknown world, I thought of
+Gatsby’s wonder when he first picked out the green light at the end of
+Daisy’s dock. He had come a long way to this blue lawn, and his dream
+must have seemed so close that he could hardly fail to grasp it. He
+did not know that it was already behind him, somewhere back in that
+vast obscurity beyond the city, where the dark fields of the republic
+rolled on under the night.
+
+Gatsby believed in the green light, the orgastic future that year by
+year recedes before us. It eluded us then, but that’s no
+matter—tomorrow we will run faster, stretch out our arms further … And
+one fine morning—
+
+So we beat on, boats against the current, borne back ceaselessly into
+the past.
+
+
+        
+            *** END OF THE PROJECT GUTENBERG EBOOK THE GREAT GATSBY ***
+        
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™ electronic works
+
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+
+  
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+
+
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+
+1.F.
+
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+
+Section 4. Information about Donations to the Project Gutenberg Literary Archive Foundation
+
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/examples/ordered_wordcount/run_ordered_wordcount.py
+++ b/examples/ordered_wordcount/run_ordered_wordcount.py
@@ -54,7 +54,11 @@ def main():
     )
 
     # Create and dispatch the campaign
-    campaign = Campaign("Word count campaign", activities=[activity_1, activity_2, activity_3], logger=logger)
+    campaign = Campaign(
+        "Word count campaign",
+        activities=[activity_1, activity_2, activity_3],
+        logger=logger,
+    )
     campaign.dispatch()
 
 

--- a/examples/ordered_wordcount/wizard_of_oz_book.txt
+++ b/examples/ordered_wordcount/wizard_of_oz_book.txt
@@ -1,0 +1,5130 @@
+﻿The Project Gutenberg eBook of The Wonderful Wizard of Oz, by L. Frank Baum
+
+This eBook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org. If you are not located in the United States, you
+will have to check the laws of the country where you are located before
+using this eBook.
+
+Title: The Wonderful Wizard of Oz
+
+Author: L. Frank Baum
+
+Release Date: February, 1993 [eBook #55]
+[Most recently updated: October 19, 2020]
+
+Language: English
+
+Character set encoding: UTF-8
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK THE WONDERFUL WIZARD OF OZ ***
+
+[Illustration]
+
+
+
+
+The Wonderful Wizard of Oz
+
+by L. Frank Baum
+
+
+This book is dedicated to my good friend & comrade
+My Wife
+L.F.B.
+
+
+Contents
+
+ Introduction
+ Chapter I. The Cyclone
+ Chapter II. The Council with the Munchkins
+ Chapter III. How Dorothy Saved the Scarecrow
+ Chapter IV. The Road Through the Forest
+ Chapter V. The Rescue of the Tin Woodman
+ Chapter VI.  The Cowardly Lion
+ Chapter VII. The Journey to the Great Oz
+ Chapter VIII. The Deadly Poppy Field
+ Chapter IX. The Queen of the Field Mice
+ Chapter X. The Guardian of the Gates
+ Chapter XI. The Emerald City of Oz
+ Chapter XII. The Search for the Wicked Witch
+ Chapter XIII. The Rescue
+ Chapter XIV. The Winged Monkeys
+ Chapter XV. The Discovery of Oz, the Terrible
+ Chapter XVI. The Magic Art of the Great Humbug
+ Chapter XVII. How the Balloon Was Launched
+ Chapter XVIII. Away to the South
+ Chapter XIX. Attacked by the Fighting Trees
+ Chapter XX. The Dainty China Country
+ Chapter XXI. The Lion Becomes the King of Beasts
+ Chapter XXII. The Country of the Quadlings
+ Chapter XXIII. Glinda The Good Witch Grants Dorothy’s Wish
+ Chapter XXIV. Home Again
+
+
+
+
+Introduction
+
+
+Folklore, legends, myths and fairy tales have followed childhood
+through the ages, for every healthy youngster has a wholesome and
+instinctive love for stories fantastic, marvelous and manifestly
+unreal. The winged fairies of Grimm and Andersen have brought more
+happiness to childish hearts than all other human creations.
+
+Yet the old time fairy tale, having served for generations, may now be
+classed as “historical” in the children’s library; for the time has
+come for a series of newer “wonder tales” in which the stereotyped
+genie, dwarf and fairy are eliminated, together with all the horrible
+and blood-curdling incidents devised by their authors to point a
+fearsome moral to each tale. Modern education includes morality;
+therefore the modern child seeks only entertainment in its wonder tales
+and gladly dispenses with all disagreeable incident.
+
+Having this thought in mind, the story of “The Wonderful Wizard of Oz”
+was written solely to please children of today. It aspires to being a
+modernized fairy tale, in which the wonderment and joy are retained and
+the heartaches and nightmares are left out.
+
+L. Frank Baum
+Chicago, April, 1900.
+
+
+
+The Wonderful Wizard of Oz
+
+
+
+
+Chapter I
+The Cyclone
+
+
+Dorothy lived in the midst of the great Kansas prairies, with Uncle
+Henry, who was a farmer, and Aunt Em, who was the farmer’s wife. Their
+house was small, for the lumber to build it had to be carried by wagon
+many miles. There were four walls, a floor and a roof, which made one
+room; and this room contained a rusty looking cookstove, a cupboard for
+the dishes, a table, three or four chairs, and the beds. Uncle Henry
+and Aunt Em had a big bed in one corner, and Dorothy a little bed in
+another corner. There was no garret at all, and no cellar—except a
+small hole dug in the ground, called a cyclone cellar, where the family
+could go in case one of those great whirlwinds arose, mighty enough to
+crush any building in its path. It was reached by a trap door in the
+middle of the floor, from which a ladder led down into the small, dark
+hole.
+
+When Dorothy stood in the doorway and looked around, she could see
+nothing but the great gray prairie on every side. Not a tree nor a
+house broke the broad sweep of flat country that reached to the edge of
+the sky in all directions. The sun had baked the plowed land into a
+gray mass, with little cracks running through it. Even the grass was
+not green, for the sun had burned the tops of the long blades until
+they were the same gray color to be seen everywhere. Once the house had
+been painted, but the sun blistered the paint and the rains washed it
+away, and now the house was as dull and gray as everything else.
+
+When Aunt Em came there to live she was a young, pretty wife. The sun
+and wind had changed her, too. They had taken the sparkle from her eyes
+and left them a sober gray; they had taken the red from her cheeks and
+lips, and they were gray also. She was thin and gaunt, and never smiled
+now. When Dorothy, who was an orphan, first came to her, Aunt Em had
+been so startled by the child’s laughter that she would scream and
+press her hand upon her heart whenever Dorothy’s merry voice reached
+her ears; and she still looked at the little girl with wonder that she
+could find anything to laugh at.
+
+Uncle Henry never laughed. He worked hard from morning till night and
+did not know what joy was. He was gray also, from his long beard to his
+rough boots, and he looked stern and solemn, and rarely spoke.
+
+It was Toto that made Dorothy laugh, and saved her from growing as gray
+as her other surroundings. Toto was not gray; he was a little black
+dog, with long silky hair and small black eyes that twinkled merrily on
+either side of his funny, wee nose. Toto played all day long, and
+Dorothy played with him, and loved him dearly.
+
+Today, however, they were not playing. Uncle Henry sat upon the
+doorstep and looked anxiously at the sky, which was even grayer than
+usual. Dorothy stood in the door with Toto in her arms, and looked at
+the sky too. Aunt Em was washing the dishes.
+
+From the far north they heard a low wail of the wind, and Uncle Henry
+and Dorothy could see where the long grass bowed in waves before the
+coming storm. There now came a sharp whistling in the air from the
+south, and as they turned their eyes that way they saw ripples in the
+grass coming from that direction also.
+
+Suddenly Uncle Henry stood up.
+
+“There’s a cyclone coming, Em,” he called to his wife. “I’ll go look
+after the stock.” Then he ran toward the sheds where the cows and
+horses were kept.
+
+Aunt Em dropped her work and came to the door. One glance told her of
+the danger close at hand.
+
+“Quick, Dorothy!” she screamed. “Run for the cellar!”
+
+Toto jumped out of Dorothy’s arms and hid under the bed, and the girl
+started to get him. Aunt Em, badly frightened, threw open the trap door
+in the floor and climbed down the ladder into the small, dark hole.
+Dorothy caught Toto at last and started to follow her aunt. When she
+was halfway across the room there came a great shriek from the wind,
+and the house shook so hard that she lost her footing and sat down
+suddenly upon the floor.
+
+Then a strange thing happened.
+
+The house whirled around two or three times and rose slowly through the
+air. Dorothy felt as if she were going up in a balloon.
+
+The north and south winds met where the house stood, and made it the
+exact center of the cyclone. In the middle of a cyclone the air is
+generally still, but the great pressure of the wind on every side of
+the house raised it up higher and higher, until it was at the very top
+of the cyclone; and there it remained and was carried miles and miles
+away as easily as you could carry a feather.
+
+It was very dark, and the wind howled horribly around her, but Dorothy
+found she was riding quite easily. After the first few whirls around,
+and one other time when the house tipped badly, she felt as if she were
+being rocked gently, like a baby in a cradle.
+
+Toto did not like it. He ran about the room, now here, now there,
+barking loudly; but Dorothy sat quite still on the floor and waited to
+see what would happen.
+
+Once Toto got too near the open trap door, and fell in; and at first
+the little girl thought she had lost him. But soon she saw one of his
+ears sticking up through the hole, for the strong pressure of the air
+was keeping him up so that he could not fall. She crept to the hole,
+caught Toto by the ear, and dragged him into the room again, afterward
+closing the trap door so that no more accidents could happen.
+
+Hour after hour passed away, and slowly Dorothy got over her fright;
+but she felt quite lonely, and the wind shrieked so loudly all about
+her that she nearly became deaf. At first she had wondered if she would
+be dashed to pieces when the house fell again; but as the hours passed
+and nothing terrible happened, she stopped worrying and resolved to
+wait calmly and see what the future would bring. At last she crawled
+over the swaying floor to her bed, and lay down upon it; and Toto
+followed and lay down beside her.
+
+In spite of the swaying of the house and the wailing of the wind,
+Dorothy soon closed her eyes and fell fast asleep.
+
+
+
+
+Chapter II
+The Council with the Munchkins
+
+
+She was awakened by a shock, so sudden and severe that if Dorothy had
+not been lying on the soft bed she might have been hurt. As it was, the
+jar made her catch her breath and wonder what had happened; and Toto
+put his cold little nose into her face and whined dismally. Dorothy sat
+up and noticed that the house was not moving; nor was it dark, for the
+bright sunshine came in at the window, flooding the little room. She
+sprang from her bed and with Toto at her heels ran and opened the door.
+
+The little girl gave a cry of amazement and looked about her, her eyes
+growing bigger and bigger at the wonderful sights she saw.
+
+The cyclone had set the house down very gently—for a cyclone—in the
+midst of a country of marvelous beauty. There were lovely patches of
+greensward all about, with stately trees bearing rich and luscious
+fruits. Banks of gorgeous flowers were on every hand, and birds with
+rare and brilliant plumage sang and fluttered in the trees and bushes.
+A little way off was a small brook, rushing and sparkling along between
+green banks, and murmuring in a voice very grateful to a little girl
+who had lived so long on the dry, gray prairies.
+
+While she stood looking eagerly at the strange and beautiful sights,
+she noticed coming toward her a group of the queerest people she had
+ever seen. They were not as big as the grown folk she had always been
+used to; but neither were they very small. In fact, they seemed about
+as tall as Dorothy, who was a well-grown child for her age, although
+they were, so far as looks go, many years older.
+
+Three were men and one a woman, and all were oddly dressed. They wore
+round hats that rose to a small point a foot above their heads, with
+little bells around the brims that tinkled sweetly as they moved. The
+hats of the men were blue; the little woman’s hat was white, and she
+wore a white gown that hung in pleats from her shoulders. Over it were
+sprinkled little stars that glistened in the sun like diamonds. The men
+were dressed in blue, of the same shade as their hats, and wore
+well-polished boots with a deep roll of blue at the tops. The men,
+Dorothy thought, were about as old as Uncle Henry, for two of them had
+beards. But the little woman was doubtless much older. Her face was
+covered with wrinkles, her hair was nearly white, and she walked rather
+stiffly.
+
+When these people drew near the house where Dorothy was standing in the
+doorway, they paused and whispered among themselves, as if afraid to
+come farther. But the little old woman walked up to Dorothy, made a low
+bow and said, in a sweet voice:
+
+“You are welcome, most noble Sorceress, to the land of the Munchkins.
+We are so grateful to you for having killed the Wicked Witch of the
+East, and for setting our people free from bondage.”
+
+Dorothy listened to this speech with wonder. What could the little
+woman possibly mean by calling her a sorceress, and saying she had
+killed the Wicked Witch of the East? Dorothy was an innocent, harmless
+little girl, who had been carried by a cyclone many miles from home;
+and she had never killed anything in all her life.
+
+But the little woman evidently expected her to answer; so Dorothy said,
+with hesitation, “You are very kind, but there must be some mistake. I
+have not killed anything.”
+
+“Your house did, anyway,” replied the little old woman, with a laugh,
+“and that is the same thing. See!” she continued, pointing to the
+corner of the house. “There are her two feet, still sticking out from
+under a block of wood.”
+
+Dorothy looked, and gave a little cry of fright. There, indeed, just
+under the corner of the great beam the house rested on, two feet were
+sticking out, shod in silver shoes with pointed toes.
+
+“Oh, dear! Oh, dear!” cried Dorothy, clasping her hands together in
+dismay. “The house must have fallen on her. Whatever shall we do?”
+
+“There is nothing to be done,” said the little woman calmly.
+
+“But who was she?” asked Dorothy.
+
+“She was the Wicked Witch of the East, as I said,” answered the little
+woman. “She has held all the Munchkins in bondage for many years,
+making them slave for her night and day. Now they are all set free, and
+are grateful to you for the favor.”
+
+“Who are the Munchkins?” inquired Dorothy.
+
+“They are the people who live in this land of the East where the Wicked
+Witch ruled.”
+
+“Are you a Munchkin?” asked Dorothy.
+
+“No, but I am their friend, although I live in the land of the North.
+When they saw the Witch of the East was dead the Munchkins sent a swift
+messenger to me, and I came at once. I am the Witch of the North.”
+
+“Oh, gracious!” cried Dorothy. “Are you a real witch?”
+
+“Yes, indeed,” answered the little woman. “But I am a good witch, and
+the people love me. I am not as powerful as the Wicked Witch was who
+ruled here, or I should have set the people free myself.”
+
+“But I thought all witches were wicked,” said the girl, who was half
+frightened at facing a real witch. “Oh, no, that is a great mistake.
+There were only four witches in all the Land of Oz, and two of them,
+those who live in the North and the South, are good witches. I know
+this is true, for I am one of them myself, and cannot be mistaken.
+Those who dwelt in the East and the West were, indeed, wicked witches;
+but now that you have killed one of them, there is but one Wicked Witch
+in all the Land of Oz—the one who lives in the West.”
+
+“But,” said Dorothy, after a moment’s thought, “Aunt Em has told me
+that the witches were all dead—years and years ago.”
+
+“Who is Aunt Em?” inquired the little old woman.
+
+“She is my aunt who lives in Kansas, where I came from.”
+
+The Witch of the North seemed to think for a time, with her head bowed
+and her eyes upon the ground. Then she looked up and said, “I do not
+know where Kansas is, for I have never heard that country mentioned
+before. But tell me, is it a civilized country?”
+
+“Oh, yes,” replied Dorothy.
+
+“Then that accounts for it. In the civilized countries I believe there
+are no witches left, nor wizards, nor sorceresses, nor magicians. But,
+you see, the Land of Oz has never been civilized, for we are cut off
+from all the rest of the world. Therefore we still have witches and
+wizards amongst us.”
+
+“Who are the wizards?” asked Dorothy.
+
+“Oz himself is the Great Wizard,” answered the Witch, sinking her voice
+to a whisper. “He is more powerful than all the rest of us together. He
+lives in the City of Emeralds.”
+
+Dorothy was going to ask another question, but just then the Munchkins,
+who had been standing silently by, gave a loud shout and pointed to the
+corner of the house where the Wicked Witch had been lying.
+
+“What is it?” asked the little old woman, and looked, and began to
+laugh. The feet of the dead Witch had disappeared entirely, and nothing
+was left but the silver shoes.
+
+“She was so old,” explained the Witch of the North, “that she dried up
+quickly in the sun. That is the end of her. But the silver shoes are
+yours, and you shall have them to wear.” She reached down and picked up
+the shoes, and after shaking the dust out of them handed them to
+Dorothy.
+
+“The Witch of the East was proud of those silver shoes,” said one of
+the Munchkins, “and there is some charm connected with them; but what
+it is we never knew.”
+
+Dorothy carried the shoes into the house and placed them on the table.
+Then she came out again to the Munchkins and said:
+
+“I am anxious to get back to my aunt and uncle, for I am sure they will
+worry about me. Can you help me find my way?”
+
+The Munchkins and the Witch first looked at one another, and then at
+Dorothy, and then shook their heads.
+
+“At the East, not far from here,” said one, “there is a great desert,
+and none could live to cross it.”
+
+“It is the same at the South,” said another, “for I have been there and
+seen it. The South is the country of the Quadlings.”
+
+“I am told,” said the third man, “that it is the same at the West. And
+that country, where the Winkies live, is ruled by the Wicked Witch of
+the West, who would make you her slave if you passed her way.”
+
+“The North is my home,” said the old lady, “and at its edge is the same
+great desert that surrounds this Land of Oz. I’m afraid, my dear, you
+will have to live with us.”
+
+Dorothy began to sob at this, for she felt lonely among all these
+strange people. Her tears seemed to grieve the kind-hearted Munchkins,
+for they immediately took out their handkerchiefs and began to weep
+also. As for the little old woman, she took off her cap and balanced
+the point on the end of her nose, while she counted “One, two, three”
+in a solemn voice. At once the cap changed to a slate, on which was
+written in big, white chalk marks:
+
+“LET DOROTHY GO TO THE CITY OF EMERALDS”
+
+
+The little old woman took the slate from her nose, and having read the
+words on it, asked, “Is your name Dorothy, my dear?”
+
+“Yes,” answered the child, looking up and drying her tears.
+
+“Then you must go to the City of Emeralds. Perhaps Oz will help you.”
+
+“Where is this city?” asked Dorothy.
+
+“It is exactly in the center of the country, and is ruled by Oz, the
+Great Wizard I told you of.”
+
+“Is he a good man?” inquired the girl anxiously.
+
+“He is a good Wizard. Whether he is a man or not I cannot tell, for I
+have never seen him.”
+
+“How can I get there?” asked Dorothy.
+
+“You must walk. It is a long journey, through a country that is
+sometimes pleasant and sometimes dark and terrible. However, I will use
+all the magic arts I know of to keep you from harm.”
+
+“Won’t you go with me?” pleaded the girl, who had begun to look upon
+the little old woman as her only friend.
+
+“No, I cannot do that,” she replied, “but I will give you my kiss, and
+no one will dare injure a person who has been kissed by the Witch of
+the North.”
+
+She came close to Dorothy and kissed her gently on the forehead. Where
+her lips touched the girl they left a round, shining mark, as Dorothy
+found out soon after.
+
+“The road to the City of Emeralds is paved with yellow brick,” said the
+Witch, “so you cannot miss it. When you get to Oz do not be afraid of
+him, but tell your story and ask him to help you. Good-bye, my dear.”
+
+The three Munchkins bowed low to her and wished her a pleasant journey,
+after which they walked away through the trees. The Witch gave Dorothy
+a friendly little nod, whirled around on her left heel three times, and
+straightway disappeared, much to the surprise of little Toto, who
+barked after her loudly enough when she had gone, because he had been
+afraid even to growl while she stood by.
+
+But Dorothy, knowing her to be a witch, had expected her to disappear
+in just that way, and was not surprised in the least.
+
+
+
+
+Chapter III
+How Dorothy Saved the Scarecrow
+
+
+When Dorothy was left alone she began to feel hungry. So she went to
+the cupboard and cut herself some bread, which she spread with butter.
+She gave some to Toto, and taking a pail from the shelf she carried it
+down to the little brook and filled it with clear, sparkling water.
+Toto ran over to the trees and began to bark at the birds sitting
+there. Dorothy went to get him, and saw such delicious fruit hanging
+from the branches that she gathered some of it, finding it just what
+she wanted to help out her breakfast.
+
+Then she went back to the house, and having helped herself and Toto to
+a good drink of the cool, clear water, she set about making ready for
+the journey to the City of Emeralds.
+
+Dorothy had only one other dress, but that happened to be clean and was
+hanging on a peg beside her bed. It was gingham, with checks of white
+and blue; and although the blue was somewhat faded with many washings,
+it was still a pretty frock. The girl washed herself carefully, dressed
+herself in the clean gingham, and tied her pink sunbonnet on her head.
+She took a little basket and filled it with bread from the cupboard,
+laying a white cloth over the top. Then she looked down at her feet and
+noticed how old and worn her shoes were.
+
+“They surely will never do for a long journey, Toto,” she said. And
+Toto looked up into her face with his little black eyes and wagged his
+tail to show he knew what she meant.
+
+At that moment Dorothy saw lying on the table the silver shoes that had
+belonged to the Witch of the East.
+
+“I wonder if they will fit me,” she said to Toto. “They would be just
+the thing to take a long walk in, for they could not wear out.”
+
+She took off her old leather shoes and tried on the silver ones, which
+fitted her as well as if they had been made for her.
+
+Finally she picked up her basket.
+
+“Come along, Toto,” she said. “We will go to the Emerald City and ask
+the Great Oz how to get back to Kansas again.”
+
+She closed the door, locked it, and put the key carefully in the pocket
+of her dress. And so, with Toto trotting along soberly behind her, she
+started on her journey.
+
+There were several roads nearby, but it did not take her long to find
+the one paved with yellow bricks. Within a short time she was walking
+briskly toward the Emerald City, her silver shoes tinkling merrily on
+the hard, yellow road-bed. The sun shone bright and the birds sang
+sweetly, and Dorothy did not feel nearly so bad as you might think a
+little girl would who had been suddenly whisked away from her own
+country and set down in the midst of a strange land.
+
+She was surprised, as she walked along, to see how pretty the country
+was about her. There were neat fences at the sides of the road, painted
+a dainty blue color, and beyond them were fields of grain and
+vegetables in abundance. Evidently the Munchkins were good farmers and
+able to raise large crops. Once in a while she would pass a house, and
+the people came out to look at her and bow low as she went by; for
+everyone knew she had been the means of destroying the Wicked Witch and
+setting them free from bondage. The houses of the Munchkins were
+odd-looking dwellings, for each was round, with a big dome for a roof.
+All were painted blue, for in this country of the East blue was the
+favorite color.
+
+Toward evening, when Dorothy was tired with her long walk and began to
+wonder where she should pass the night, she came to a house rather
+larger than the rest. On the green lawn before it many men and women
+were dancing. Five little fiddlers played as loudly as possible, and
+the people were laughing and singing, while a big table near by was
+loaded with delicious fruits and nuts, pies and cakes, and many other
+good things to eat.
+
+The people greeted Dorothy kindly, and invited her to supper and to
+pass the night with them; for this was the home of one of the richest
+Munchkins in the land, and his friends were gathered with him to
+celebrate their freedom from the bondage of the Wicked Witch.
+
+Dorothy ate a hearty supper and was waited upon by the rich Munchkin
+himself, whose name was Boq. Then she sat upon a settee and watched the
+people dance.
+
+When Boq saw her silver shoes he said, “You must be a great sorceress.”
+
+“Why?” asked the girl.
+
+“Because you wear silver shoes and have killed the Wicked Witch.
+Besides, you have white in your frock, and only witches and sorceresses
+wear white.”
+
+“My dress is blue and white checked,” said Dorothy, smoothing out the
+wrinkles in it.
+
+“It is kind of you to wear that,” said Boq. “Blue is the color of the
+Munchkins, and white is the witch color. So we know you are a friendly
+witch.”
+
+Dorothy did not know what to say to this, for all the people seemed to
+think her a witch, and she knew very well she was only an ordinary
+little girl who had come by the chance of a cyclone into a strange
+land.
+
+When she had tired watching the dancing, Boq led her into the house,
+where he gave her a room with a pretty bed in it. The sheets were made
+of blue cloth, and Dorothy slept soundly in them till morning, with
+Toto curled up on the blue rug beside her.
+
+She ate a hearty breakfast, and watched a wee Munchkin baby, who played
+with Toto and pulled his tail and crowed and laughed in a way that
+greatly amused Dorothy. Toto was a fine curiosity to all the people,
+for they had never seen a dog before.
+
+“How far is it to the Emerald City?” the girl asked.
+
+“I do not know,” answered Boq gravely, “for I have never been there. It
+is better for people to keep away from Oz, unless they have business
+with him. But it is a long way to the Emerald City, and it will take
+you many days. The country here is rich and pleasant, but you must pass
+through rough and dangerous places before you reach the end of your
+journey.”
+
+This worried Dorothy a little, but she knew that only the Great Oz
+could help her get to Kansas again, so she bravely resolved not to turn
+back.
+
+She bade her friends good-bye, and again started along the road of
+yellow brick. When she had gone several miles she thought she would
+stop to rest, and so climbed to the top of the fence beside the road
+and sat down. There was a great cornfield beyond the fence, and not far
+away she saw a Scarecrow, placed high on a pole to keep the birds from
+the ripe corn.
+
+Dorothy leaned her chin upon her hand and gazed thoughtfully at the
+Scarecrow. Its head was a small sack stuffed with straw, with eyes,
+nose, and mouth painted on it to represent a face. An old, pointed blue
+hat, that had belonged to some Munchkin, was perched on his head, and
+the rest of the figure was a blue suit of clothes, worn and faded,
+which had also been stuffed with straw. On the feet were some old boots
+with blue tops, such as every man wore in this country, and the figure
+was raised above the stalks of corn by means of the pole stuck up its
+back.
+
+While Dorothy was looking earnestly into the queer, painted face of the
+Scarecrow, she was surprised to see one of the eyes slowly wink at her.
+She thought she must have been mistaken at first, for none of the
+scarecrows in Kansas ever wink; but presently the figure nodded its
+head to her in a friendly way. Then she climbed down from the fence and
+walked up to it, while Toto ran around the pole and barked.
+
+“Good day,” said the Scarecrow, in a rather husky voice.
+
+“Did you speak?” asked the girl, in wonder.
+
+“Certainly,” answered the Scarecrow. “How do you do?”
+
+“I’m pretty well, thank you,” replied Dorothy politely. “How do you
+do?”
+
+“I’m not feeling well,” said the Scarecrow, with a smile, “for it is
+very tedious being perched up here night and day to scare away crows.”
+
+“Can’t you get down?” asked Dorothy.
+
+“No, for this pole is stuck up my back. If you will please take away
+the pole I shall be greatly obliged to you.”
+
+Dorothy reached up both arms and lifted the figure off the pole, for,
+being stuffed with straw, it was quite light.
+
+“Thank you very much,” said the Scarecrow, when he had been set down on
+the ground. “I feel like a new man.”
+
+Dorothy was puzzled at this, for it sounded queer to hear a stuffed man
+speak, and to see him bow and walk along beside her.
+
+“Who are you?” asked the Scarecrow when he had stretched himself and
+yawned. “And where are you going?”
+
+“My name is Dorothy,” said the girl, “and I am going to the Emerald
+City, to ask the Great Oz to send me back to Kansas.”
+
+“Where is the Emerald City?” he inquired. “And who is Oz?”
+
+“Why, don’t you know?” she returned, in surprise.
+
+“No, indeed. I don’t know anything. You see, I am stuffed, so I have no
+brains at all,” he answered sadly.
+
+“Oh,” said Dorothy, “I’m awfully sorry for you.”
+
+“Do you think,” he asked, “if I go to the Emerald City with you, that
+Oz would give me some brains?”
+
+“I cannot tell,” she returned, “but you may come with me, if you like.
+If Oz will not give you any brains you will be no worse off than you
+are now.”
+
+“That is true,” said the Scarecrow. “You see,” he continued
+confidentially, “I don’t mind my legs and arms and body being stuffed,
+because I cannot get hurt. If anyone treads on my toes or sticks a pin
+into me, it doesn’t matter, for I can’t feel it. But I do not want
+people to call me a fool, and if my head stays stuffed with straw
+instead of with brains, as yours is, how am I ever to know anything?”
+
+“I understand how you feel,” said the little girl, who was truly sorry
+for him. “If you will come with me I’ll ask Oz to do all he can for
+you.”
+
+“Thank you,” he answered gratefully.
+
+They walked back to the road. Dorothy helped him over the fence, and
+they started along the path of yellow brick for the Emerald City.
+
+Toto did not like this addition to the party at first. He smelled
+around the stuffed man as if he suspected there might be a nest of rats
+in the straw, and he often growled in an unfriendly way at the
+Scarecrow.
+
+“Don’t mind Toto,” said Dorothy to her new friend. “He never bites.”
+
+“Oh, I’m not afraid,” replied the Scarecrow. “He can’t hurt the straw.
+Do let me carry that basket for you. I shall not mind it, for I can’t
+get tired. I’ll tell you a secret,” he continued, as he walked along.
+“There is only one thing in the world I am afraid of.”
+
+“What is that?” asked Dorothy; “the Munchkin farmer who made you?”
+
+“No,” answered the Scarecrow; “it’s a lighted match.”
+
+
+
+
+Chapter IV
+The Road Through the Forest
+
+
+After a few hours the road began to be rough, and the walking grew so
+difficult that the Scarecrow often stumbled over the yellow bricks,
+which were here very uneven. Sometimes, indeed, they were broken or
+missing altogether, leaving holes that Toto jumped across and Dorothy
+walked around. As for the Scarecrow, having no brains, he walked
+straight ahead, and so stepped into the holes and fell at full length
+on the hard bricks. It never hurt him, however, and Dorothy would pick
+him up and set him upon his feet again, while he joined her in laughing
+merrily at his own mishap.
+
+The farms were not nearly so well cared for here as they were farther
+back. There were fewer houses and fewer fruit trees, and the farther
+they went the more dismal and lonesome the country became.
+
+At noon they sat down by the roadside, near a little brook, and Dorothy
+opened her basket and got out some bread. She offered a piece to the
+Scarecrow, but he refused.
+
+“I am never hungry,” he said, “and it is a lucky thing I am not, for my
+mouth is only painted, and if I should cut a hole in it so I could eat,
+the straw I am stuffed with would come out, and that would spoil the
+shape of my head.”
+
+Dorothy saw at once that this was true, so she only nodded and went on
+eating her bread.
+
+“Tell me something about yourself and the country you came from,” said
+the Scarecrow, when she had finished her dinner. So she told him all
+about Kansas, and how gray everything was there, and how the cyclone
+had carried her to this queer Land of Oz.
+
+The Scarecrow listened carefully, and said, “I cannot understand why
+you should wish to leave this beautiful country and go back to the dry,
+gray place you call Kansas.”
+
+“That is because you have no brains” answered the girl. “No matter how
+dreary and gray our homes are, we people of flesh and blood would
+rather live there than in any other country, be it ever so beautiful.
+There is no place like home.”
+
+The Scarecrow sighed.
+
+“Of course I cannot understand it,” he said. “If your heads were
+stuffed with straw, like mine, you would probably all live in the
+beautiful places, and then Kansas would have no people at all. It is
+fortunate for Kansas that you have brains.”
+
+“Won’t you tell me a story, while we are resting?” asked the child.
+
+The Scarecrow looked at her reproachfully, and answered:
+
+“My life has been so short that I really know nothing whatever. I was
+only made day before yesterday. What happened in the world before that
+time is all unknown to me. Luckily, when the farmer made my head, one
+of the first things he did was to paint my ears, so that I heard what
+was going on. There was another Munchkin with him, and the first thing
+I heard was the farmer saying, ‘How do you like those ears?’
+
+“‘They aren’t straight,’” answered the other.
+
+“‘Never mind,’” said the farmer. “‘They are ears just the same,’” which
+was true enough.
+
+“‘Now I’ll make the eyes,’” said the farmer. So he painted my right
+eye, and as soon as it was finished I found myself looking at him and
+at everything around me with a great deal of curiosity, for this was my
+first glimpse of the world.
+
+“‘That’s a rather pretty eye,’” remarked the Munchkin who was watching
+the farmer. “‘Blue paint is just the color for eyes.’
+
+“‘I think I’ll make the other a little bigger,’” said the farmer. And
+when the second eye was done I could see much better than before. Then
+he made my nose and my mouth. But I did not speak, because at that time
+I didn’t know what a mouth was for. I had the fun of watching them make
+my body and my arms and legs; and when they fastened on my head, at
+last, I felt very proud, for I thought I was just as good a man as
+anyone.
+
+“‘This fellow will scare the crows fast enough,’ said the farmer. ‘He
+looks just like a man.’
+
+“‘Why, he is a man,’ said the other, and I quite agreed with him. The
+farmer carried me under his arm to the cornfield, and set me up on a
+tall stick, where you found me. He and his friend soon after walked
+away and left me alone.
+
+“I did not like to be deserted this way. So I tried to walk after them.
+But my feet would not touch the ground, and I was forced to stay on
+that pole. It was a lonely life to lead, for I had nothing to think of,
+having been made such a little while before. Many crows and other birds
+flew into the cornfield, but as soon as they saw me they flew away
+again, thinking I was a Munchkin; and this pleased me and made me feel
+that I was quite an important person. By and by an old crow flew near
+me, and after looking at me carefully he perched upon my shoulder and
+said:
+
+“‘I wonder if that farmer thought to fool me in this clumsy manner. Any
+crow of sense could see that you are only stuffed with straw.’ Then he
+hopped down at my feet and ate all the corn he wanted. The other birds,
+seeing he was not harmed by me, came to eat the corn too, so in a short
+time there was a great flock of them about me.
+
+“I felt sad at this, for it showed I was not such a good Scarecrow
+after all; but the old crow comforted me, saying, ‘If you only had
+brains in your head you would be as good a man as any of them, and a
+better man than some of them. Brains are the only things worth having
+in this world, no matter whether one is a crow or a man.’
+
+“After the crows had gone I thought this over, and decided I would try
+hard to get some brains. By good luck you came along and pulled me off
+the stake, and from what you say I am sure the Great Oz will give me
+brains as soon as we get to the Emerald City.”
+
+“I hope so,” said Dorothy earnestly, “since you seem anxious to have
+them.”
+
+“Oh, yes; I am anxious,” returned the Scarecrow. “It is such an
+uncomfortable feeling to know one is a fool.”
+
+“Well,” said the girl, “let us go.” And she handed the basket to the
+Scarecrow.
+
+There were no fences at all by the roadside now, and the land was rough
+and untilled. Toward evening they came to a great forest, where the
+trees grew so big and close together that their branches met over the
+road of yellow brick. It was almost dark under the trees, for the
+branches shut out the daylight; but the travelers did not stop, and
+went on into the forest.
+
+“If this road goes in, it must come out,” said the Scarecrow, “and as
+the Emerald City is at the other end of the road, we must go wherever
+it leads us.”
+
+“Anyone would know that,” said Dorothy.
+
+“Certainly; that is why I know it,” returned the Scarecrow. “If it
+required brains to figure it out, I never should have said it.”
+
+After an hour or so the light faded away, and they found themselves
+stumbling along in the darkness. Dorothy could not see at all, but Toto
+could, for some dogs see very well in the dark; and the Scarecrow
+declared he could see as well as by day. So she took hold of his arm
+and managed to get along fairly well.
+
+“If you see any house, or any place where we can pass the night,” she
+said, “you must tell me; for it is very uncomfortable walking in the
+dark.”
+
+Soon after the Scarecrow stopped.
+
+“I see a little cottage at the right of us,” he said, “built of logs
+and branches. Shall we go there?”
+
+“Yes, indeed,” answered the child. “I am all tired out.”
+
+So the Scarecrow led her through the trees until they reached the
+cottage, and Dorothy entered and found a bed of dried leaves in one
+corner. She lay down at once, and with Toto beside her soon fell into a
+sound sleep. The Scarecrow, who was never tired, stood up in another
+corner and waited patiently until morning came.
+
+
+
+
+Chapter V
+The Rescue of the Tin Woodman
+
+
+When Dorothy awoke the sun was shining through the trees and Toto had
+long been out chasing birds around him and squirrels. She sat up and
+looked around her. There was the Scarecrow, still standing patiently in
+his corner, waiting for her.
+
+“We must go and search for water,” she said to him.
+
+“Why do you want water?” he asked.
+
+“To wash my face clean after the dust of the road, and to drink, so the
+dry bread will not stick in my throat.”
+
+“It must be inconvenient to be made of flesh,” said the Scarecrow
+thoughtfully, “for you must sleep, and eat and drink. However, you have
+brains, and it is worth a lot of bother to be able to think properly.”
+
+They left the cottage and walked through the trees until they found a
+little spring of clear water, where Dorothy drank and bathed and ate
+her breakfast. She saw there was not much bread left in the basket, and
+the girl was thankful the Scarecrow did not have to eat anything, for
+there was scarcely enough for herself and Toto for the day.
+
+When she had finished her meal, and was about to go back to the road of
+yellow brick, she was startled to hear a deep groan near by.
+
+“What was that?” she asked timidly.
+
+“I cannot imagine,” replied the Scarecrow; “but we can go and see.”
+
+Just then another groan reached their ears, and the sound seemed to
+come from behind them. They turned and walked through the forest a few
+steps, when Dorothy discovered something shining in a ray of sunshine
+that fell between the trees. She ran to the place and then stopped
+short, with a little cry of surprise.
+
+One of the big trees had been partly chopped through, and standing
+beside it, with an uplifted axe in his hands, was a man made entirely
+of tin. His head and arms and legs were jointed upon his body, but he
+stood perfectly motionless, as if he could not stir at all.
+
+Dorothy looked at him in amazement, and so did the Scarecrow, while
+Toto barked sharply and made a snap at the tin legs, which hurt his
+teeth.
+
+“Did you groan?” asked Dorothy.
+
+“Yes,” answered the tin man, “I did. I’ve been groaning for more than a
+year, and no one has ever heard me before or come to help me.”
+
+“What can I do for you?” she inquired softly, for she was moved by the
+sad voice in which the man spoke.
+
+“Get an oil-can and oil my joints,” he answered. “They are rusted so
+badly that I cannot move them at all; if I am well oiled I shall soon
+be all right again. You will find an oil-can on a shelf in my cottage.”
+
+Dorothy at once ran back to the cottage and found the oil-can, and then
+she returned and asked anxiously, “Where are your joints?”
+
+“Oil my neck, first,” replied the Tin Woodman. So she oiled it, and as
+it was quite badly rusted the Scarecrow took hold of the tin head and
+moved it gently from side to side until it worked freely, and then the
+man could turn it himself.
+
+“Now oil the joints in my arms,” he said. And Dorothy oiled them and
+the Scarecrow bent them carefully until they were quite free from rust
+and as good as new.
+
+The Tin Woodman gave a sigh of satisfaction and lowered his axe, which
+he leaned against the tree.
+
+“This is a great comfort,” he said. “I have been holding that axe in
+the air ever since I rusted, and I’m glad to be able to put it down at
+last. Now, if you will oil the joints of my legs, I shall be all right
+once more.”
+
+So they oiled his legs until he could move them freely; and he thanked
+them again and again for his release, for he seemed a very polite
+creature, and very grateful.
+
+“I might have stood there always if you had not come along,” he said;
+“so you have certainly saved my life. How did you happen to be here?”
+
+“We are on our way to the Emerald City to see the Great Oz,” she
+answered, “and we stopped at your cottage to pass the night.”
+
+“Why do you wish to see Oz?” he asked.
+
+“I want him to send me back to Kansas, and the Scarecrow wants him to
+put a few brains into his head,” she replied.
+
+The Tin Woodman appeared to think deeply for a moment. Then he said:
+
+“Do you suppose Oz could give me a heart?”
+
+“Why, I guess so,” Dorothy answered. “It would be as easy as to give
+the Scarecrow brains.”
+
+“True,” the Tin Woodman returned. “So, if you will allow me to join
+your party, I will also go to the Emerald City and ask Oz to help me.”
+
+“Come along,” said the Scarecrow heartily, and Dorothy added that she
+would be pleased to have his company. So the Tin Woodman shouldered his
+axe and they all passed through the forest until they came to the road
+that was paved with yellow brick.
+
+The Tin Woodman had asked Dorothy to put the oil-can in her basket.
+“For,” he said, “if I should get caught in the rain, and rust again, I
+would need the oil-can badly.”
+
+It was a bit of good luck to have their new comrade join the party, for
+soon after they had begun their journey again they came to a place
+where the trees and branches grew so thick over the road that the
+travelers could not pass. But the Tin Woodman set to work with his axe
+and chopped so well that soon he cleared a passage for the entire
+party.
+
+Dorothy was thinking so earnestly as they walked along that she did not
+notice when the Scarecrow stumbled into a hole and rolled over to the
+side of the road. Indeed he was obliged to call to her to help him up
+again.
+
+“Why didn’t you walk around the hole?” asked the Tin Woodman.
+
+“I don’t know enough,” replied the Scarecrow cheerfully. “My head is
+stuffed with straw, you know, and that is why I am going to Oz to ask
+him for some brains.”
+
+“Oh, I see,” said the Tin Woodman. “But, after all, brains are not the
+best things in the world.”
+
+“Have you any?” inquired the Scarecrow.
+
+“No, my head is quite empty,” answered the Woodman. “But once I had
+brains, and a heart also; so, having tried them both, I should much
+rather have a heart.”
+
+“And why is that?” asked the Scarecrow.
+
+“I will tell you my story, and then you will know.”
+
+So, while they were walking through the forest, the Tin Woodman told
+the following story:
+
+“I was born the son of a woodman who chopped down trees in the forest
+and sold the wood for a living. When I grew up, I too became a
+woodchopper, and after my father died I took care of my old mother as
+long as she lived. Then I made up my mind that instead of living alone
+I would marry, so that I might not become lonely.
+
+“There was one of the Munchkin girls who was so beautiful that I soon
+grew to love her with all my heart. She, on her part, promised to marry
+me as soon as I could earn enough money to build a better house for
+her; so I set to work harder than ever. But the girl lived with an old
+woman who did not want her to marry anyone, for she was so lazy she
+wished the girl to remain with her and do the cooking and the
+housework. So the old woman went to the Wicked Witch of the East, and
+promised her two sheep and a cow if she would prevent the marriage.
+Thereupon the Wicked Witch enchanted my axe, and when I was chopping
+away at my best one day, for I was anxious to get the new house and my
+wife as soon as possible, the axe slipped all at once and cut off my
+left leg.
+
+“This at first seemed a great misfortune, for I knew a one-legged man
+could not do very well as a wood-chopper. So I went to a tinsmith and
+had him make me a new leg out of tin. The leg worked very well, once I
+was used to it. But my action angered the Wicked Witch of the East, for
+she had promised the old woman I should not marry the pretty Munchkin
+girl. When I began chopping again, my axe slipped and cut off my right
+leg. Again I went to the tinsmith, and again he made me a leg out of
+tin. After this the enchanted axe cut off my arms, one after the other;
+but, nothing daunted, I had them replaced with tin ones. The Wicked
+Witch then made the axe slip and cut off my head, and at first I
+thought that was the end of me. But the tinsmith happened to come
+along, and he made me a new head out of tin.
+
+“I thought I had beaten the Wicked Witch then, and I worked harder than
+ever; but I little knew how cruel my enemy could be. She thought of a
+new way to kill my love for the beautiful Munchkin maiden, and made my
+axe slip again, so that it cut right through my body, splitting me into
+two halves. Once more the tinsmith came to my help and made me a body
+of tin, fastening my tin arms and legs and head to it, by means of
+joints, so that I could move around as well as ever. But, alas! I had
+now no heart, so that I lost all my love for the Munchkin girl, and did
+not care whether I married her or not. I suppose she is still living
+with the old woman, waiting for me to come after her.
+
+“My body shone so brightly in the sun that I felt very proud of it and
+it did not matter now if my axe slipped, for it could not cut me. There
+was only one danger—that my joints would rust; but I kept an oil-can in
+my cottage and took care to oil myself whenever I needed it. However,
+there came a day when I forgot to do this, and, being caught in a
+rainstorm, before I thought of the danger my joints had rusted, and I
+was left to stand in the woods until you came to help me. It was a
+terrible thing to undergo, but during the year I stood there I had time
+to think that the greatest loss I had known was the loss of my heart.
+While I was in love I was the happiest man on earth; but no one can
+love who has not a heart, and so I am resolved to ask Oz to give me
+one. If he does, I will go back to the Munchkin maiden and marry her.”
+
+Both Dorothy and the Scarecrow had been greatly interested in the story
+of the Tin Woodman, and now they knew why he was so anxious to get a
+new heart.
+
+“All the same,” said the Scarecrow, “I shall ask for brains instead of
+a heart; for a fool would not know what to do with a heart if he had
+one.”
+
+“I shall take the heart,” returned the Tin Woodman; “for brains do not
+make one happy, and happiness is the best thing in the world.”
+
+Dorothy did not say anything, for she was puzzled to know which of her
+two friends was right, and she decided if she could only get back to
+Kansas and Aunt Em, it did not matter so much whether the Woodman had
+no brains and the Scarecrow no heart, or each got what he wanted.
+
+What worried her most was that the bread was nearly gone, and another
+meal for herself and Toto would empty the basket. To be sure, neither
+the Woodman nor the Scarecrow ever ate anything, but she was not made
+of tin nor straw, and could not live unless she was fed.
+
+
+
+
+Chapter VI
+The Cowardly Lion
+
+
+All this time Dorothy and her companions had been walking through the
+thick woods. The road was still paved with yellow brick, but these were
+much covered by dried branches and dead leaves from the trees, and the
+walking was not at all good.
+
+There were few birds in this part of the forest, for birds love the
+open country where there is plenty of sunshine. But now and then there
+came a deep growl from some wild animal hidden among the trees. These
+sounds made the little girl’s heart beat fast, for she did not know
+what made them; but Toto knew, and he walked close to Dorothy’s side,
+and did not even bark in return.
+
+“How long will it be,” the child asked of the Tin Woodman, “before we
+are out of the forest?”
+
+“I cannot tell,” was the answer, “for I have never been to the Emerald
+City. But my father went there once, when I was a boy, and he said it
+was a long journey through a dangerous country, although nearer to the
+city where Oz dwells the country is beautiful. But I am not afraid so
+long as I have my oil-can, and nothing can hurt the Scarecrow, while
+you bear upon your forehead the mark of the Good Witch’s kiss, and that
+will protect you from harm.”
+
+“But Toto!” said the girl anxiously. “What will protect him?”
+
+“We must protect him ourselves if he is in danger,” replied the Tin
+Woodman.
+
+Just as he spoke there came from the forest a terrible roar, and the
+next moment a great Lion bounded into the road. With one blow of his
+paw he sent the Scarecrow spinning over and over to the edge of the
+road, and then he struck at the Tin Woodman with his sharp claws. But,
+to the Lion’s surprise, he could make no impression on the tin,
+although the Woodman fell over in the road and lay still.
+
+Little Toto, now that he had an enemy to face, ran barking toward the
+Lion, and the great beast had opened his mouth to bite the dog, when
+Dorothy, fearing Toto would be killed, and heedless of danger, rushed
+forward and slapped the Lion upon his nose as hard as she could, while
+she cried out:
+
+“Don’t you dare to bite Toto! You ought to be ashamed of yourself, a
+big beast like you, to bite a poor little dog!”
+
+“I didn’t bite him,” said the Lion, as he rubbed his nose with his paw
+where Dorothy had hit it.
+
+“No, but you tried to,” she retorted. “You are nothing but a big
+coward.”
+
+“I know it,” said the Lion, hanging his head in shame. “I’ve always
+known it. But how can I help it?”
+
+“I don’t know, I’m sure. To think of your striking a stuffed man, like
+the poor Scarecrow!”
+
+“Is he stuffed?” asked the Lion in surprise, as he watched her pick up
+the Scarecrow and set him upon his feet, while she patted him into
+shape again.
+
+“Of course he’s stuffed,” replied Dorothy, who was still angry.
+
+“That’s why he went over so easily,” remarked the Lion. “It astonished
+me to see him whirl around so. Is the other one stuffed also?”
+
+“No,” said Dorothy, “he’s made of tin.” And she helped the Woodman up
+again.
+
+“That’s why he nearly blunted my claws,” said the Lion. “When they
+scratched against the tin it made a cold shiver run down my back. What
+is that little animal you are so tender of?”
+
+“He is my dog, Toto,” answered Dorothy.
+
+“Is he made of tin, or stuffed?” asked the Lion.
+
+“Neither. He’s a—a—a meat dog,” said the girl.
+
+“Oh! He’s a curious animal and seems remarkably small, now that I look
+at him. No one would think of biting such a little thing, except a
+coward like me,” continued the Lion sadly.
+
+“What makes you a coward?” asked Dorothy, looking at the great beast in
+wonder, for he was as big as a small horse.
+
+“It’s a mystery,” replied the Lion. “I suppose I was born that way. All
+the other animals in the forest naturally expect me to be brave, for
+the Lion is everywhere thought to be the King of Beasts. I learned that
+if I roared very loudly every living thing was frightened and got out
+of my way. Whenever I’ve met a man I’ve been awfully scared; but I just
+roared at him, and he has always run away as fast as he could go. If
+the elephants and the tigers and the bears had ever tried to fight me,
+I should have run myself—I’m such a coward; but just as soon as they
+hear me roar they all try to get away from me, and of course I let them
+go.”
+
+“But that isn’t right. The King of Beasts shouldn’t be a coward,” said
+the Scarecrow.
+
+“I know it,” returned the Lion, wiping a tear from his eye with the tip
+of his tail. “It is my great sorrow, and makes my life very unhappy.
+But whenever there is danger, my heart begins to beat fast.”
+
+“Perhaps you have heart disease,” said the Tin Woodman.
+
+“It may be,” said the Lion.
+
+“If you have,” continued the Tin Woodman, “you ought to be glad, for it
+proves you have a heart. For my part, I have no heart; so I cannot have
+heart disease.”
+
+“Perhaps,” said the Lion thoughtfully, “if I had no heart I should not
+be a coward.”
+
+“Have you brains?” asked the Scarecrow.
+
+“I suppose so. I’ve never looked to see,” replied the Lion.
+
+“I am going to the Great Oz to ask him to give me some,” remarked the
+Scarecrow, “for my head is stuffed with straw.”
+
+“And I am going to ask him to give me a heart,” said the Woodman.
+
+“And I am going to ask him to send Toto and me back to Kansas,” added
+Dorothy.
+
+“Do you think Oz could give me courage?” asked the Cowardly Lion.
+
+“Just as easily as he could give me brains,” said the Scarecrow.
+
+“Or give me a heart,” said the Tin Woodman.
+
+“Or send me back to Kansas,” said Dorothy.
+
+“Then, if you don’t mind, I’ll go with you,” said the Lion, “for my
+life is simply unbearable without a bit of courage.”
+
+“You will be very welcome,” answered Dorothy, “for you will help to
+keep away the other wild beasts. It seems to me they must be more
+cowardly than you are if they allow you to scare them so easily.”
+
+“They really are,” said the Lion, “but that doesn’t make me any braver,
+and as long as I know myself to be a coward I shall be unhappy.”
+
+So once more the little company set off upon the journey, the Lion
+walking with stately strides at Dorothy’s side. Toto did not approve of
+this new comrade at first, for he could not forget how nearly he had
+been crushed between the Lion’s great jaws. But after a time he became
+more at ease, and presently Toto and the Cowardly Lion had grown to be
+good friends.
+
+During the rest of that day there was no other adventure to mar the
+peace of their journey. Once, indeed, the Tin Woodman stepped upon a
+beetle that was crawling along the road, and killed the poor little
+thing. This made the Tin Woodman very unhappy, for he was always
+careful not to hurt any living creature; and as he walked along he wept
+several tears of sorrow and regret. These tears ran slowly down his
+face and over the hinges of his jaw, and there they rusted. When
+Dorothy presently asked him a question the Tin Woodman could not open
+his mouth, for his jaws were tightly rusted together. He became greatly
+frightened at this and made many motions to Dorothy to relieve him, but
+she could not understand. The Lion was also puzzled to know what was
+wrong. But the Scarecrow seized the oil-can from Dorothy’s basket and
+oiled the Woodman’s jaws, so that after a few moments he could talk as
+well as before.
+
+“This will serve me a lesson,” said he, “to look where I step. For if I
+should kill another bug or beetle I should surely cry again, and crying
+rusts my jaws so that I cannot speak.”
+
+Thereafter he walked very carefully, with his eyes on the road, and
+when he saw a tiny ant toiling by he would step over it, so as not to
+harm it. The Tin Woodman knew very well he had no heart, and therefore
+he took great care never to be cruel or unkind to anything.
+
+“You people with hearts,” he said, “have something to guide you, and
+need never do wrong; but I have no heart, and so I must be very
+careful. When Oz gives me a heart of course I needn’t mind so much.”
+
+
+
+
+Chapter VII
+The Journey to the Great Oz
+
+
+They were obliged to camp out that night under a large tree in the
+forest, for there were no houses near. The tree made a good, thick
+covering to protect them from the dew, and the Tin Woodman chopped a
+great pile of wood with his axe and Dorothy built a splendid fire that
+warmed her and made her feel less lonely. She and Toto ate the last of
+their bread, and now she did not know what they would do for breakfast.
+
+“If you wish,” said the Lion, “I will go into the forest and kill a
+deer for you. You can roast it by the fire, since your tastes are so
+peculiar that you prefer cooked food, and then you will have a very
+good breakfast.”
+
+“Don’t! Please don’t,” begged the Tin Woodman. “I should certainly weep
+if you killed a poor deer, and then my jaws would rust again.”
+
+But the Lion went away into the forest and found his own supper, and no
+one ever knew what it was, for he didn’t mention it. And the Scarecrow
+found a tree full of nuts and filled Dorothy’s basket with them, so
+that she would not be hungry for a long time. She thought this was very
+kind and thoughtful of the Scarecrow, but she laughed heartily at the
+awkward way in which the poor creature picked up the nuts. His padded
+hands were so clumsy and the nuts were so small that he dropped almost
+as many as he put in the basket. But the Scarecrow did not mind how
+long it took him to fill the basket, for it enabled him to keep away
+from the fire, as he feared a spark might get into his straw and burn
+him up. So he kept a good distance away from the flames, and only came
+near to cover Dorothy with dry leaves when she lay down to sleep. These
+kept her very snug and warm, and she slept soundly until morning.
+
+When it was daylight, the girl bathed her face in a little rippling
+brook, and soon after they all started toward the Emerald City.
+
+This was to be an eventful day for the travelers. They had hardly been
+walking an hour when they saw before them a great ditch that crossed
+the road and divided the forest as far as they could see on either
+side. It was a very wide ditch, and when they crept up to the edge and
+looked into it they could see it was also very deep, and there were
+many big, jagged rocks at the bottom. The sides were so steep that none
+of them could climb down, and for a moment it seemed that their journey
+must end.
+
+“What shall we do?” asked Dorothy despairingly.
+
+“I haven’t the faintest idea,” said the Tin Woodman, and the Lion shook
+his shaggy mane and looked thoughtful.
+
+But the Scarecrow said, “We cannot fly, that is certain. Neither can we
+climb down into this great ditch. Therefore, if we cannot jump over it,
+we must stop where we are.”
+
+“I think I could jump over it,” said the Cowardly Lion, after measuring
+the distance carefully in his mind.
+
+“Then we are all right,” answered the Scarecrow, “for you can carry us
+all over on your back, one at a time.”
+
+“Well, I’ll try it,” said the Lion. “Who will go first?”
+
+“I will,” declared the Scarecrow, “for, if you found that you could not
+jump over the gulf, Dorothy would be killed, or the Tin Woodman badly
+dented on the rocks below. But if I am on your back it will not matter
+so much, for the fall would not hurt me at all.”
+
+“I am terribly afraid of falling, myself,” said the Cowardly Lion, “but
+I suppose there is nothing to do but try it. So get on my back and we
+will make the attempt.”
+
+The Scarecrow sat upon the Lion’s back, and the big beast walked to the
+edge of the gulf and crouched down.
+
+“Why don’t you run and jump?” asked the Scarecrow.
+
+“Because that isn’t the way we Lions do these things,” he replied. Then
+giving a great spring, he shot through the air and landed safely on the
+other side. They were all greatly pleased to see how easily he did it,
+and after the Scarecrow had got down from his back the Lion sprang
+across the ditch again.
+
+Dorothy thought she would go next; so she took Toto in her arms and
+climbed on the Lion’s back, holding tightly to his mane with one hand.
+The next moment it seemed as if she were flying through the air; and
+then, before she had time to think about it, she was safe on the other
+side. The Lion went back a third time and got the Tin Woodman, and then
+they all sat down for a few moments to give the beast a chance to rest,
+for his great leaps had made his breath short, and he panted like a big
+dog that has been running too long.
+
+They found the forest very thick on this side, and it looked dark and
+gloomy. After the Lion had rested they started along the road of yellow
+brick, silently wondering, each in his own mind, if ever they would
+come to the end of the woods and reach the bright sunshine again. To
+add to their discomfort, they soon heard strange noises in the depths
+of the forest, and the Lion whispered to them that it was in this part
+of the country that the Kalidahs lived.
+
+“What are the Kalidahs?” asked the girl.
+
+“They are monstrous beasts with bodies like bears and heads like
+tigers,” replied the Lion, “and with claws so long and sharp that they
+could tear me in two as easily as I could kill Toto. I’m terribly
+afraid of the Kalidahs.”
+
+“I’m not surprised that you are,” returned Dorothy. “They must be
+dreadful beasts.”
+
+The Lion was about to reply when suddenly they came to another gulf
+across the road. But this one was so broad and deep that the Lion knew
+at once he could not leap across it.
+
+So they sat down to consider what they should do, and after serious
+thought the Scarecrow said:
+
+“Here is a great tree, standing close to the ditch. If the Tin Woodman
+can chop it down, so that it will fall to the other side, we can walk
+across it easily.”
+
+“That is a first-rate idea,” said the Lion. “One would almost suspect
+you had brains in your head, instead of straw.”
+
+The Woodman set to work at once, and so sharp was his axe that the tree
+was soon chopped nearly through. Then the Lion put his strong front
+legs against the tree and pushed with all his might, and slowly the big
+tree tipped and fell with a crash across the ditch, with its top
+branches on the other side.
+
+They had just started to cross this queer bridge when a sharp growl
+made them all look up, and to their horror they saw running toward them
+two great beasts with bodies like bears and heads like tigers.
+
+“They are the Kalidahs!” said the Cowardly Lion, beginning to tremble.
+
+“Quick!” cried the Scarecrow. “Let us cross over.”
+
+So Dorothy went first, holding Toto in her arms, the Tin Woodman
+followed, and the Scarecrow came next. The Lion, although he was
+certainly afraid, turned to face the Kalidahs, and then he gave so loud
+and terrible a roar that Dorothy screamed and the Scarecrow fell over
+backward, while even the fierce beasts stopped short and looked at him
+in surprise.
+
+But, seeing they were bigger than the Lion, and remembering that there
+were two of them and only one of him, the Kalidahs again rushed
+forward, and the Lion crossed over the tree and turned to see what they
+would do next. Without stopping an instant the fierce beasts also began
+to cross the tree. And the Lion said to Dorothy:
+
+“We are lost, for they will surely tear us to pieces with their sharp
+claws. But stand close behind me, and I will fight them as long as I am
+alive.”
+
+“Wait a minute!” called the Scarecrow. He had been thinking what was
+best to be done, and now he asked the Woodman to chop away the end of
+the tree that rested on their side of the ditch. The Tin Woodman began
+to use his axe at once, and, just as the two Kalidahs were nearly
+across, the tree fell with a crash into the gulf, carrying the ugly,
+snarling brutes with it, and both were dashed to pieces on the sharp
+rocks at the bottom.
+
+“Well,” said the Cowardly Lion, drawing a long breath of relief, “I see
+we are going to live a little while longer, and I am glad of it, for it
+must be a very uncomfortable thing not to be alive. Those creatures
+frightened me so badly that my heart is beating yet.”
+
+“Ah,” said the Tin Woodman sadly, “I wish I had a heart to beat.”
+
+This adventure made the travelers more anxious than ever to get out of
+the forest, and they walked so fast that Dorothy became tired, and had
+to ride on the Lion’s back. To their great joy the trees became thinner
+the farther they advanced, and in the afternoon they suddenly came upon
+a broad river, flowing swiftly just before them. On the other side of
+the water they could see the road of yellow brick running through a
+beautiful country, with green meadows dotted with bright flowers and
+all the road bordered with trees hanging full of delicious fruits. They
+were greatly pleased to see this delightful country before them.
+
+“How shall we cross the river?” asked Dorothy.
+
+“That is easily done,” replied the Scarecrow. “The Tin Woodman must
+build us a raft, so we can float to the other side.”
+
+So the Woodman took his axe and began to chop down small trees to make
+a raft, and while he was busy at this the Scarecrow found on the
+riverbank a tree full of fine fruit. This pleased Dorothy, who had
+eaten nothing but nuts all day, and she made a hearty meal of the ripe
+fruit.
+
+But it takes time to make a raft, even when one is as industrious and
+untiring as the Tin Woodman, and when night came the work was not done.
+So they found a cozy place under the trees where they slept well until
+the morning; and Dorothy dreamed of the Emerald City, and of the good
+Wizard Oz, who would soon send her back to her own home again.
+
+
+
+
+Chapter VIII
+The Deadly Poppy Field
+
+
+Our little party of travelers awakened the next morning refreshed and
+full of hope, and Dorothy breakfasted like a princess off peaches and
+plums from the trees beside the river. Behind them was the dark forest
+they had passed safely through, although they had suffered many
+discouragements; but before them was a lovely, sunny country that
+seemed to beckon them on to the Emerald City.
+
+To be sure, the broad river now cut them off from this beautiful land.
+But the raft was nearly done, and after the Tin Woodman had cut a few
+more logs and fastened them together with wooden pins, they were ready
+to start. Dorothy sat down in the middle of the raft and held Toto in
+her arms. When the Cowardly Lion stepped upon the raft it tipped badly,
+for he was big and heavy; but the Scarecrow and the Tin Woodman stood
+upon the other end to steady it, and they had long poles in their hands
+to push the raft through the water.
+
+They got along quite well at first, but when they reached the middle of
+the river the swift current swept the raft downstream, farther and
+farther away from the road of yellow brick. And the water grew so deep
+that the long poles would not touch the bottom.
+
+“This is bad,” said the Tin Woodman, “for if we cannot get to the land
+we shall be carried into the country of the Wicked Witch of the West,
+and she will enchant us and make us her slaves.”
+
+“And then I should get no brains,” said the Scarecrow.
+
+“And I should get no courage,” said the Cowardly Lion.
+
+“And I should get no heart,” said the Tin Woodman.
+
+“And I should never get back to Kansas,” said Dorothy.
+
+“We must certainly get to the Emerald City if we can,” the Scarecrow
+continued, and he pushed so hard on his long pole that it stuck fast in
+the mud at the bottom of the river. Then, before he could pull it out
+again—or let go—the raft was swept away, and the poor Scarecrow was
+left clinging to the pole in the middle of the river.
+
+“Good-bye!” he called after them, and they were very sorry to leave
+him. Indeed, the Tin Woodman began to cry, but fortunately remembered
+that he might rust, and so dried his tears on Dorothy’s apron.
+
+Of course this was a bad thing for the Scarecrow.
+
+“I am now worse off than when I first met Dorothy,” he thought. “Then,
+I was stuck on a pole in a cornfield, where I could make-believe scare
+the crows, at any rate. But surely there is no use for a Scarecrow
+stuck on a pole in the middle of a river. I am afraid I shall never
+have any brains, after all!”
+
+Down the stream the raft floated, and the poor Scarecrow was left far
+behind. Then the Lion said:
+
+“Something must be done to save us. I think I can swim to the shore and
+pull the raft after me, if you will only hold fast to the tip of my
+tail.”
+
+So he sprang into the water, and the Tin Woodman caught fast hold of
+his tail. Then the Lion began to swim with all his might toward the
+shore. It was hard work, although he was so big; but by and by they
+were drawn out of the current, and then Dorothy took the Tin Woodman’s
+long pole and helped push the raft to the land.
+
+They were all tired out when they reached the shore at last and stepped
+off upon the pretty green grass, and they also knew that the stream had
+carried them a long way past the road of yellow brick that led to the
+Emerald City.
+
+“What shall we do now?” asked the Tin Woodman, as the Lion lay down on
+the grass to let the sun dry him.
+
+“We must get back to the road, in some way,” said Dorothy.
+
+“The best plan will be to walk along the riverbank until we come to the
+road again,” remarked the Lion.
+
+So, when they were rested, Dorothy picked up her basket and they
+started along the grassy bank, to the road from which the river had
+carried them. It was a lovely country, with plenty of flowers and fruit
+trees and sunshine to cheer them, and had they not felt so sorry for
+the poor Scarecrow, they could have been very happy.
+
+They walked along as fast as they could, Dorothy only stopping once to
+pick a beautiful flower; and after a time the Tin Woodman cried out:
+“Look!”
+
+Then they all looked at the river and saw the Scarecrow perched upon
+his pole in the middle of the water, looking very lonely and sad.
+
+“What can we do to save him?” asked Dorothy.
+
+The Lion and the Woodman both shook their heads, for they did not know.
+So they sat down upon the bank and gazed wistfully at the Scarecrow
+until a Stork flew by, who, upon seeing them, stopped to rest at the
+water’s edge.
+
+“Who are you and where are you going?” asked the Stork.
+
+“I am Dorothy,” answered the girl, “and these are my friends, the Tin
+Woodman and the Cowardly Lion; and we are going to the Emerald City.”
+
+“This isn’t the road,” said the Stork, as she twisted her long neck and
+looked sharply at the queer party.
+
+“I know it,” returned Dorothy, “but we have lost the Scarecrow, and are
+wondering how we shall get him again.”
+
+“Where is he?” asked the Stork.
+
+“Over there in the river,” answered the little girl.
+
+“If he wasn’t so big and heavy I would get him for you,” remarked the
+Stork.
+
+“He isn’t heavy a bit,” said Dorothy eagerly, “for he is stuffed with
+straw; and if you will bring him back to us, we shall thank you ever
+and ever so much.”
+
+“Well, I’ll try,” said the Stork, “but if I find he is too heavy to
+carry I shall have to drop him in the river again.”
+
+So the big bird flew into the air and over the water till she came to
+where the Scarecrow was perched upon his pole. Then the Stork with her
+great claws grabbed the Scarecrow by the arm and carried him up into
+the air and back to the bank, where Dorothy and the Lion and the Tin
+Woodman and Toto were sitting.
+
+When the Scarecrow found himself among his friends again, he was so
+happy that he hugged them all, even the Lion and Toto; and as they
+walked along he sang “Tol-de-ri-de-oh!” at every step, he felt so gay.
+
+“I was afraid I should have to stay in the river forever,” he said,
+“but the kind Stork saved me, and if I ever get any brains I shall find
+the Stork again and do her some kindness in return.”
+
+“That’s all right,” said the Stork, who was flying along beside them.
+“I always like to help anyone in trouble. But I must go now, for my
+babies are waiting in the nest for me. I hope you will find the Emerald
+City and that Oz will help you.”
+
+“Thank you,” replied Dorothy, and then the kind Stork flew into the air
+and was soon out of sight.
+
+They walked along listening to the singing of the brightly colored
+birds and looking at the lovely flowers which now became so thick that
+the ground was carpeted with them. There were big yellow and white and
+blue and purple blossoms, besides great clusters of scarlet poppies,
+which were so brilliant in color they almost dazzled Dorothy’s eyes.
+
+“Aren’t they beautiful?” the girl asked, as she breathed in the spicy
+scent of the bright flowers.
+
+“I suppose so,” answered the Scarecrow. “When I have brains, I shall
+probably like them better.”
+
+“If I only had a heart, I should love them,” added the Tin Woodman.
+
+“I always did like flowers,” said the Lion. “They seem so helpless and
+frail. But there are none in the forest so bright as these.”
+
+They now came upon more and more of the big scarlet poppies, and fewer
+and fewer of the other flowers; and soon they found themselves in the
+midst of a great meadow of poppies. Now it is well known that when
+there are many of these flowers together their odor is so powerful that
+anyone who breathes it falls asleep, and if the sleeper is not carried
+away from the scent of the flowers, he sleeps on and on forever. But
+Dorothy did not know this, nor could she get away from the bright red
+flowers that were everywhere about; so presently her eyes grew heavy
+and she felt she must sit down to rest and to sleep.
+
+But the Tin Woodman would not let her do this.
+
+“We must hurry and get back to the road of yellow brick before dark,”
+he said; and the Scarecrow agreed with him. So they kept walking until
+Dorothy could stand no longer. Her eyes closed in spite of herself and
+she forgot where she was and fell among the poppies, fast asleep.
+
+“What shall we do?” asked the Tin Woodman.
+
+“If we leave her here she will die,” said the Lion. “The smell of the
+flowers is killing us all. I myself can scarcely keep my eyes open, and
+the dog is asleep already.”
+
+It was true; Toto had fallen down beside his little mistress. But the
+Scarecrow and the Tin Woodman, not being made of flesh, were not
+troubled by the scent of the flowers.
+
+“Run fast,” said the Scarecrow to the Lion, “and get out of this deadly
+flower bed as soon as you can. We will bring the little girl with us,
+but if you should fall asleep you are too big to be carried.”
+
+So the Lion aroused himself and bounded forward as fast as he could go.
+In a moment he was out of sight.
+
+“Let us make a chair with our hands and carry her,” said the Scarecrow.
+So they picked up Toto and put the dog in Dorothy’s lap, and then they
+made a chair with their hands for the seat and their arms for the arms
+and carried the sleeping girl between them through the flowers.
+
+On and on they walked, and it seemed that the great carpet of deadly
+flowers that surrounded them would never end. They followed the bend of
+the river, and at last came upon their friend the Lion, lying fast
+asleep among the poppies. The flowers had been too strong for the huge
+beast and he had given up at last, and fallen only a short distance
+from the end of the poppy bed, where the sweet grass spread in
+beautiful green fields before them.
+
+“We can do nothing for him,” said the Tin Woodman, sadly; “for he is
+much too heavy to lift. We must leave him here to sleep on forever, and
+perhaps he will dream that he has found courage at last.”
+
+“I’m sorry,” said the Scarecrow. “The Lion was a very good comrade for
+one so cowardly. But let us go on.”
+
+They carried the sleeping girl to a pretty spot beside the river, far
+enough from the poppy field to prevent her breathing any more of the
+poison of the flowers, and here they laid her gently on the soft grass
+and waited for the fresh breeze to waken her.
+
+
+
+
+Chapter IX
+The Queen of the Field Mice
+
+
+“We cannot be far from the road of yellow brick, now,” remarked the
+Scarecrow, as he stood beside the girl, “for we have come nearly as far
+as the river carried us away.”
+
+The Tin Woodman was about to reply when he heard a low growl, and
+turning his head (which worked beautifully on hinges) he saw a strange
+beast come bounding over the grass toward them. It was, indeed, a great
+yellow Wildcat, and the Woodman thought it must be chasing something,
+for its ears were lying close to its head and its mouth was wide open,
+showing two rows of ugly teeth, while its red eyes glowed like balls of
+fire. As it came nearer the Tin Woodman saw that running before the
+beast was a little gray field mouse, and although he had no heart he
+knew it was wrong for the Wildcat to try to kill such a pretty,
+harmless creature.
+
+So the Woodman raised his axe, and as the Wildcat ran by he gave it a
+quick blow that cut the beast’s head clean off from its body, and it
+rolled over at his feet in two pieces.
+
+The field mouse, now that it was freed from its enemy, stopped short;
+and coming slowly up to the Woodman it said, in a squeaky little voice:
+
+“Oh, thank you! Thank you ever so much for saving my life.”
+
+“Don’t speak of it, I beg of you,” replied the Woodman. “I have no
+heart, you know, so I am careful to help all those who may need a
+friend, even if it happens to be only a mouse.”
+
+“Only a mouse!” cried the little animal, indignantly. “Why, I am a
+Queen—the Queen of all the Field Mice!”
+
+“Oh, indeed,” said the Woodman, making a bow.
+
+“Therefore you have done a great deed, as well as a brave one, in
+saving my life,” added the Queen.
+
+At that moment several mice were seen running up as fast as their
+little legs could carry them, and when they saw their Queen they
+exclaimed:
+
+“Oh, your Majesty, we thought you would be killed! How did you manage
+to escape the great Wildcat?” They all bowed so low to the little Queen
+that they almost stood upon their heads.
+
+“This funny tin man,” she answered, “killed the Wildcat and saved my
+life. So hereafter you must all serve him, and obey his slightest
+wish.”
+
+“We will!” cried all the mice, in a shrill chorus. And then they
+scampered in all directions, for Toto had awakened from his sleep, and
+seeing all these mice around him he gave one bark of delight and jumped
+right into the middle of the group. Toto had always loved to chase mice
+when he lived in Kansas, and he saw no harm in it.
+
+But the Tin Woodman caught the dog in his arms and held him tight,
+while he called to the mice, “Come back! Come back! Toto shall not hurt
+you.”
+
+At this the Queen of the Mice stuck her head out from underneath a
+clump of grass and asked, in a timid voice, “Are you sure he will not
+bite us?”
+
+“I will not let him,” said the Woodman; “so do not be afraid.”
+
+One by one the mice came creeping back, and Toto did not bark again,
+although he tried to get out of the Woodman’s arms, and would have
+bitten him had he not known very well he was made of tin. Finally one
+of the biggest mice spoke.
+
+“Is there anything we can do,” it asked, “to repay you for saving the
+life of our Queen?”
+
+“Nothing that I know of,” answered the Woodman; but the Scarecrow, who
+had been trying to think, but could not because his head was stuffed
+with straw, said, quickly, “Oh, yes; you can save our friend, the
+Cowardly Lion, who is asleep in the poppy bed.”
+
+“A Lion!” cried the little Queen. “Why, he would eat us all up.”
+
+“Oh, no,” declared the Scarecrow; “this Lion is a coward.”
+
+“Really?” asked the Mouse.
+
+“He says so himself,” answered the Scarecrow, “and he would never hurt
+anyone who is our friend. If you will help us to save him I promise
+that he shall treat you all with kindness.”
+
+“Very well,” said the Queen, “we trust you. But what shall we do?”
+
+“Are there many of these mice which call you Queen and are willing to
+obey you?”
+
+“Oh, yes; there are thousands,” she replied.
+
+“Then send for them all to come here as soon as possible, and let each
+one bring a long piece of string.”
+
+The Queen turned to the mice that attended her and told them to go at
+once and get all her people. As soon as they heard her orders they ran
+away in every direction as fast as possible.
+
+“Now,” said the Scarecrow to the Tin Woodman, “you must go to those
+trees by the riverside and make a truck that will carry the Lion.”
+
+So the Woodman went at once to the trees and began to work; and he soon
+made a truck out of the limbs of trees, from which he chopped away all
+the leaves and branches. He fastened it together with wooden pegs and
+made the four wheels out of short pieces of a big tree trunk. So fast
+and so well did he work that by the time the mice began to arrive the
+truck was all ready for them.
+
+They came from all directions, and there were thousands of them: big
+mice and little mice and middle-sized mice; and each one brought a
+piece of string in his mouth. It was about this time that Dorothy woke
+from her long sleep and opened her eyes. She was greatly astonished to
+find herself lying upon the grass, with thousands of mice standing
+around and looking at her timidly. But the Scarecrow told her about
+everything, and turning to the dignified little Mouse, he said:
+
+“Permit me to introduce to you her Majesty, the Queen.”
+
+Dorothy nodded gravely and the Queen made a curtsy, after which she
+became quite friendly with the little girl.
+
+The Scarecrow and the Woodman now began to fasten the mice to the
+truck, using the strings they had brought. One end of a string was tied
+around the neck of each mouse and the other end to the truck. Of course
+the truck was a thousand times bigger than any of the mice who were to
+draw it; but when all the mice had been harnessed, they were able to
+pull it quite easily. Even the Scarecrow and the Tin Woodman could sit
+on it, and were drawn swiftly by their queer little horses to the place
+where the Lion lay asleep.
+
+After a great deal of hard work, for the Lion was heavy, they managed
+to get him up on the truck. Then the Queen hurriedly gave her people
+the order to start, for she feared if the mice stayed among the poppies
+too long they also would fall asleep.
+
+At first the little creatures, many though they were, could hardly stir
+the heavily loaded truck; but the Woodman and the Scarecrow both pushed
+from behind, and they got along better. Soon they rolled the Lion out
+of the poppy bed to the green fields, where he could breathe the sweet,
+fresh air again, instead of the poisonous scent of the flowers.
+
+Dorothy came to meet them and thanked the little mice warmly for saving
+her companion from death. She had grown so fond of the big Lion she was
+glad he had been rescued.
+
+Then the mice were unharnessed from the truck and scampered away
+through the grass to their homes. The Queen of the Mice was the last to
+leave.
+
+“If ever you need us again,” she said, “come out into the field and
+call, and we shall hear you and come to your assistance. Good-bye!”
+
+“Good-bye!” they all answered, and away the Queen ran, while Dorothy
+held Toto tightly lest he should run after her and frighten her.
+
+After this they sat down beside the Lion until he should awaken; and
+the Scarecrow brought Dorothy some fruit from a tree near by, which she
+ate for her dinner.
+
+
+
+
+Chapter X
+The Guardian of the Gate
+
+
+It was some time before the Cowardly Lion awakened, for he had lain
+among the poppies a long while, breathing in their deadly fragrance;
+but when he did open his eyes and roll off the truck he was very glad
+to find himself still alive.
+
+“I ran as fast as I could,” he said, sitting down and yawning, “but the
+flowers were too strong for me. How did you get me out?”
+
+Then they told him of the field mice, and how they had generously saved
+him from death; and the Cowardly Lion laughed, and said:
+
+“I have always thought myself very big and terrible; yet such little
+things as flowers came near to killing me, and such small animals as
+mice have saved my life. How strange it all is! But, comrades, what
+shall we do now?”
+
+“We must journey on until we find the road of yellow brick again,” said
+Dorothy, “and then we can keep on to the Emerald City.”
+
+So, the Lion being fully refreshed, and feeling quite himself again,
+they all started upon the journey, greatly enjoying the walk through
+the soft, fresh grass; and it was not long before they reached the road
+of yellow brick and turned again toward the Emerald City where the
+Great Oz dwelt.
+
+The road was smooth and well paved, now, and the country about was
+beautiful, so that the travelers rejoiced in leaving the forest far
+behind, and with it the many dangers they had met in its gloomy shades.
+Once more they could see fences built beside the road; but these were
+painted green, and when they came to a small house, in which a farmer
+evidently lived, that also was painted green. They passed by several of
+these houses during the afternoon, and sometimes people came to the
+doors and looked at them as if they would like to ask questions; but no
+one came near them nor spoke to them because of the great Lion, of
+which they were very much afraid. The people were all dressed in
+clothing of a lovely emerald-green color and wore peaked hats like
+those of the Munchkins.
+
+“This must be the Land of Oz,” said Dorothy, “and we are surely getting
+near the Emerald City.”
+
+“Yes,” answered the Scarecrow. “Everything is green here, while in the
+country of the Munchkins blue was the favorite color. But the people do
+not seem to be as friendly as the Munchkins, and I’m afraid we shall be
+unable to find a place to pass the night.”
+
+“I should like something to eat besides fruit,” said the girl, “and I’m
+sure Toto is nearly starved. Let us stop at the next house and talk to
+the people.”
+
+So, when they came to a good-sized farmhouse, Dorothy walked boldly up
+to the door and knocked.
+
+A woman opened it just far enough to look out, and said, “What do you
+want, child, and why is that great Lion with you?”
+
+“We wish to pass the night with you, if you will allow us,” answered
+Dorothy; “and the Lion is my friend and comrade, and would not hurt you
+for the world.”
+
+“Is he tame?” asked the woman, opening the door a little wider.
+
+“Oh, yes,” said the girl, “and he is a great coward, too. He will be
+more afraid of you than you are of him.”
+
+“Well,” said the woman, after thinking it over and taking another peep
+at the Lion, “if that is the case you may come in, and I will give you
+some supper and a place to sleep.”
+
+So they all entered the house, where there were, besides the woman, two
+children and a man. The man had hurt his leg, and was lying on the
+couch in a corner. They seemed greatly surprised to see so strange a
+company, and while the woman was busy laying the table the man asked:
+
+“Where are you all going?”
+
+“To the Emerald City,” said Dorothy, “to see the Great Oz.”
+
+“Oh, indeed!” exclaimed the man. “Are you sure that Oz will see you?”
+
+“Why not?” she replied.
+
+“Why, it is said that he never lets anyone come into his presence. I
+have been to the Emerald City many times, and it is a beautiful and
+wonderful place; but I have never been permitted to see the Great Oz,
+nor do I know of any living person who has seen him.”
+
+“Does he never go out?” asked the Scarecrow.
+
+“Never. He sits day after day in the great Throne Room of his Palace,
+and even those who wait upon him do not see him face to face.”
+
+“What is he like?” asked the girl.
+
+“That is hard to tell,” said the man thoughtfully. “You see, Oz is a
+Great Wizard, and can take on any form he wishes. So that some say he
+looks like a bird; and some say he looks like an elephant; and some say
+he looks like a cat. To others he appears as a beautiful fairy, or a
+brownie, or in any other form that pleases him. But who the real Oz is,
+when he is in his own form, no living person can tell.”
+
+“That is very strange,” said Dorothy, “but we must try, in some way, to
+see him, or we shall have made our journey for nothing.”
+
+“Why do you wish to see the terrible Oz?” asked the man.
+
+“I want him to give me some brains,” said the Scarecrow eagerly.
+
+“Oh, Oz could do that easily enough,” declared the man. “He has more
+brains than he needs.”
+
+“And I want him to give me a heart,” said the Tin Woodman.
+
+“That will not trouble him,” continued the man, “for Oz has a large
+collection of hearts, of all sizes and shapes.”
+
+“And I want him to give me courage,” said the Cowardly Lion.
+
+“Oz keeps a great pot of courage in his Throne Room,” said the man,
+“which he has covered with a golden plate, to keep it from running
+over. He will be glad to give you some.”
+
+“And I want him to send me back to Kansas,” said Dorothy.
+
+“Where is Kansas?” asked the man, with surprise.
+
+“I don’t know,” replied Dorothy sorrowfully, “but it is my home, and
+I’m sure it’s somewhere.”
+
+“Very likely. Well, Oz can do anything; so I suppose he will find
+Kansas for you. But first you must get to see him, and that will be a
+hard task; for the Great Wizard does not like to see anyone, and he
+usually has his own way. But what do YOU want?” he continued, speaking
+to Toto. Toto only wagged his tail; for, strange to say, he could not
+speak.
+
+The woman now called to them that supper was ready, so they gathered
+around the table and Dorothy ate some delicious porridge and a dish of
+scrambled eggs and a plate of nice white bread, and enjoyed her meal.
+The Lion ate some of the porridge, but did not care for it, saying it
+was made from oats and oats were food for horses, not for lions. The
+Scarecrow and the Tin Woodman ate nothing at all. Toto ate a little of
+everything, and was glad to get a good supper again.
+
+The woman now gave Dorothy a bed to sleep in, and Toto lay down beside
+her, while the Lion guarded the door of her room so she might not be
+disturbed. The Scarecrow and the Tin Woodman stood up in a corner and
+kept quiet all night, although of course they could not sleep.
+
+The next morning, as soon as the sun was up, they started on their way,
+and soon saw a beautiful green glow in the sky just before them.
+
+“That must be the Emerald City,” said Dorothy.
+
+As they walked on, the green glow became brighter and brighter, and it
+seemed that at last they were nearing the end of their travels. Yet it
+was afternoon before they came to the great wall that surrounded the
+City. It was high and thick and of a bright green color.
+
+In front of them, and at the end of the road of yellow brick, was a big
+gate, all studded with emeralds that glittered so in the sun that even
+the painted eyes of the Scarecrow were dazzled by their brilliancy.
+
+There was a bell beside the gate, and Dorothy pushed the button and
+heard a silvery tinkle sound within. Then the big gate swung slowly
+open, and they all passed through and found themselves in a high arched
+room, the walls of which glistened with countless emeralds.
+
+Before them stood a little man about the same size as the Munchkins. He
+was clothed all in green, from his head to his feet, and even his skin
+was of a greenish tint. At his side was a large green box.
+
+When he saw Dorothy and her companions the man asked, “What do you wish
+in the Emerald City?”
+
+“We came here to see the Great Oz,” said Dorothy.
+
+The man was so surprised at this answer that he sat down to think it
+over.
+
+“It has been many years since anyone asked me to see Oz,” he said,
+shaking his head in perplexity. “He is powerful and terrible, and if
+you come on an idle or foolish errand to bother the wise reflections of
+the Great Wizard, he might be angry and destroy you all in an instant.”
+
+“But it is not a foolish errand, nor an idle one,” replied the
+Scarecrow; “it is important. And we have been told that Oz is a good
+Wizard.”
+
+“So he is,” said the green man, “and he rules the Emerald City wisely
+and well. But to those who are not honest, or who approach him from
+curiosity, he is most terrible, and few have ever dared ask to see his
+face. I am the Guardian of the Gates, and since you demand to see the
+Great Oz I must take you to his Palace. But first you must put on the
+spectacles.”
+
+“Why?” asked Dorothy.
+
+“Because if you did not wear spectacles the brightness and glory of the
+Emerald City would blind you. Even those who live in the City must wear
+spectacles night and day. They are all locked on, for Oz so ordered it
+when the City was first built, and I have the only key that will unlock
+them.”
+
+He opened the big box, and Dorothy saw that it was filled with
+spectacles of every size and shape. All of them had green glasses in
+them. The Guardian of the Gates found a pair that would just fit
+Dorothy and put them over her eyes. There were two golden bands
+fastened to them that passed around the back of her head, where they
+were locked together by a little key that was at the end of a chain the
+Guardian of the Gates wore around his neck. When they were on, Dorothy
+could not take them off had she wished, but of course she did not wish
+to be blinded by the glare of the Emerald City, so she said nothing.
+
+Then the green man fitted spectacles for the Scarecrow and the Tin
+Woodman and the Lion, and even on little Toto; and all were locked fast
+with the key.
+
+Then the Guardian of the Gates put on his own glasses and told them he
+was ready to show them to the Palace. Taking a big golden key from a
+peg on the wall, he opened another gate, and they all followed him
+through the portal into the streets of the Emerald City.
+
+
+
+
+Chapter XI
+The Wonderful City of Oz
+
+
+Even with eyes protected by the green spectacles, Dorothy and her
+friends were at first dazzled by the brilliancy of the wonderful City.
+The streets were lined with beautiful houses all built of green marble
+and studded everywhere with sparkling emeralds. They walked over a
+pavement of the same green marble, and where the blocks were joined
+together were rows of emeralds, set closely, and glittering in the
+brightness of the sun. The window panes were of green glass; even the
+sky above the City had a green tint, and the rays of the sun were
+green.
+
+There were many people—men, women, and children—walking about, and
+these were all dressed in green clothes and had greenish skins. They
+looked at Dorothy and her strangely assorted company with wondering
+eyes, and the children all ran away and hid behind their mothers when
+they saw the Lion; but no one spoke to them. Many shops stood in the
+street, and Dorothy saw that everything in them was green. Green candy
+and green pop corn were offered for sale, as well as green shoes, green
+hats, and green clothes of all sorts. At one place a man was selling
+green lemonade, and when the children bought it Dorothy could see that
+they paid for it with green pennies.
+
+There seemed to be no horses nor animals of any kind; the men carried
+things around in little green carts, which they pushed before them.
+Everyone seemed happy and contented and prosperous.
+
+The Guardian of the Gates led them through the streets until they came
+to a big building, exactly in the middle of the City, which was the
+Palace of Oz, the Great Wizard. There was a soldier before the door,
+dressed in a green uniform and wearing a long green beard.
+
+“Here are strangers,” said the Guardian of the Gates to him, “and they
+demand to see the Great Oz.”
+
+“Step inside,” answered the soldier, “and I will carry your message to
+him.”
+
+So they passed through the Palace Gates and were led into a big room
+with a green carpet and lovely green furniture set with emeralds. The
+soldier made them all wipe their feet upon a green mat before entering
+this room, and when they were seated he said politely:
+
+“Please make yourselves comfortable while I go to the door of the
+Throne Room and tell Oz you are here.”
+
+They had to wait a long time before the soldier returned. When, at
+last, he came back, Dorothy asked:
+
+“Have you seen Oz?”
+
+“Oh, no,” returned the soldier; “I have never seen him. But I spoke to
+him as he sat behind his screen and gave him your message. He said he
+will grant you an audience, if you so desire; but each one of you must
+enter his presence alone, and he will admit but one each day.
+Therefore, as you must remain in the Palace for several days, I will
+have you shown to rooms where you may rest in comfort after your
+journey.”
+
+“Thank you,” replied the girl; “that is very kind of Oz.”
+
+The soldier now blew upon a green whistle, and at once a young girl,
+dressed in a pretty green silk gown, entered the room. She had lovely
+green hair and green eyes, and she bowed low before Dorothy as she
+said, “Follow me and I will show you your room.”
+
+So Dorothy said good-bye to all her friends except Toto, and taking the
+dog in her arms followed the green girl through seven passages and up
+three flights of stairs until they came to a room at the front of the
+Palace. It was the sweetest little room in the world, with a soft
+comfortable bed that had sheets of green silk and a green velvet
+counterpane. There was a tiny fountain in the middle of the room, that
+shot a spray of green perfume into the air, to fall back into a
+beautifully carved green marble basin. Beautiful green flowers stood in
+the windows, and there was a shelf with a row of little green books.
+When Dorothy had time to open these books she found them full of queer
+green pictures that made her laugh, they were so funny.
+
+In a wardrobe were many green dresses, made of silk and satin and
+velvet; and all of them fitted Dorothy exactly.
+
+“Make yourself perfectly at home,” said the green girl, “and if you
+wish for anything ring the bell. Oz will send for you tomorrow
+morning.”
+
+She left Dorothy alone and went back to the others. These she also led
+to rooms, and each one of them found himself lodged in a very pleasant
+part of the Palace. Of course this politeness was wasted on the
+Scarecrow; for when he found himself alone in his room he stood
+stupidly in one spot, just within the doorway, to wait till morning. It
+would not rest him to lie down, and he could not close his eyes; so he
+remained all night staring at a little spider which was weaving its web
+in a corner of the room, just as if it were not one of the most
+wonderful rooms in the world. The Tin Woodman lay down on his bed from
+force of habit, for he remembered when he was made of flesh; but not
+being able to sleep, he passed the night moving his joints up and down
+to make sure they kept in good working order. The Lion would have
+preferred a bed of dried leaves in the forest, and did not like being
+shut up in a room; but he had too much sense to let this worry him, so
+he sprang upon the bed and rolled himself up like a cat and purred
+himself asleep in a minute.
+
+The next morning, after breakfast, the green maiden came to fetch
+Dorothy, and she dressed her in one of the prettiest gowns, made of
+green brocaded satin. Dorothy put on a green silk apron and tied a
+green ribbon around Toto’s neck, and they started for the Throne Room
+of the Great Oz.
+
+First they came to a great hall in which were many ladies and gentlemen
+of the court, all dressed in rich costumes. These people had nothing to
+do but talk to each other, but they always came to wait outside the
+Throne Room every morning, although they were never permitted to see
+Oz. As Dorothy entered they looked at her curiously, and one of them
+whispered:
+
+“Are you really going to look upon the face of Oz the Terrible?”
+
+“Of course,” answered the girl, “if he will see me.”
+
+“Oh, he will see you,” said the soldier who had taken her message to
+the Wizard, “although he does not like to have people ask to see him.
+Indeed, at first he was angry and said I should send you back where you
+came from. Then he asked me what you looked like, and when I mentioned
+your silver shoes he was very much interested. At last I told him about
+the mark upon your forehead, and he decided he would admit you to his
+presence.”
+
+Just then a bell rang, and the green girl said to Dorothy, “That is the
+signal. You must go into the Throne Room alone.”
+
+She opened a little door and Dorothy walked boldly through and found
+herself in a wonderful place. It was a big, round room with a high
+arched roof, and the walls and ceiling and floor were covered with
+large emeralds set closely together. In the center of the roof was a
+great light, as bright as the sun, which made the emeralds sparkle in a
+wonderful manner.
+
+But what interested Dorothy most was the big throne of green marble
+that stood in the middle of the room. It was shaped like a chair and
+sparkled with gems, as did everything else. In the center of the chair
+was an enormous Head, without a body to support it or any arms or legs
+whatever. There was no hair upon this head, but it had eyes and a nose
+and mouth, and was much bigger than the head of the biggest giant.
+
+As Dorothy gazed upon this in wonder and fear, the eyes turned slowly
+and looked at her sharply and steadily. Then the mouth moved, and
+Dorothy heard a voice say:
+
+“I am Oz, the Great and Terrible. Who are you, and why do you seek me?”
+
+It was not such an awful voice as she had expected to come from the big
+Head; so she took courage and answered:
+
+“I am Dorothy, the Small and Meek. I have come to you for help.”
+
+The eyes looked at her thoughtfully for a full minute. Then said the
+voice:
+
+“Where did you get the silver shoes?”
+
+“I got them from the Wicked Witch of the East, when my house fell on
+her and killed her,” she replied.
+
+“Where did you get the mark upon your forehead?” continued the voice.
+
+“That is where the Good Witch of the North kissed me when she bade me
+good-bye and sent me to you,” said the girl.
+
+Again the eyes looked at her sharply, and they saw she was telling the
+truth. Then Oz asked, “What do you wish me to do?”
+
+“Send me back to Kansas, where my Aunt Em and Uncle Henry are,” she
+answered earnestly. “I don’t like your country, although it is so
+beautiful. And I am sure Aunt Em will be dreadfully worried over my
+being away so long.”
+
+The eyes winked three times, and then they turned up to the ceiling and
+down to the floor and rolled around so queerly that they seemed to see
+every part of the room. And at last they looked at Dorothy again.
+
+“Why should I do this for you?” asked Oz.
+
+“Because you are strong and I am weak; because you are a Great Wizard
+and I am only a little girl.”
+
+“But you were strong enough to kill the Wicked Witch of the East,” said
+Oz.
+
+“That just happened,” returned Dorothy simply; “I could not help it.”
+
+“Well,” said the Head, “I will give you my answer. You have no right to
+expect me to send you back to Kansas unless you do something for me in
+return. In this country everyone must pay for everything he gets. If
+you wish me to use my magic power to send you home again you must do
+something for me first. Help me and I will help you.”
+
+“What must I do?” asked the girl.
+
+“Kill the Wicked Witch of the West,” answered Oz.
+
+“But I cannot!” exclaimed Dorothy, greatly surprised.
+
+“You killed the Witch of the East and you wear the silver shoes, which
+bear a powerful charm. There is now but one Wicked Witch left in all
+this land, and when you can tell me she is dead I will send you back to
+Kansas—but not before.”
+
+The little girl began to weep, she was so much disappointed; and the
+eyes winked again and looked upon her anxiously, as if the Great Oz
+felt that she could help him if she would.
+
+“I never killed anything, willingly,” she sobbed. “Even if I wanted to,
+how could I kill the Wicked Witch? If you, who are Great and Terrible,
+cannot kill her yourself, how do you expect me to do it?”
+
+“I do not know,” said the Head; “but that is my answer, and until the
+Wicked Witch dies you will not see your uncle and aunt again. Remember
+that the Witch is Wicked—tremendously Wicked—and ought to be killed.
+Now go, and do not ask to see me again until you have done your task.”
+
+Sorrowfully Dorothy left the Throne Room and went back where the Lion
+and the Scarecrow and the Tin Woodman were waiting to hear what Oz had
+said to her. “There is no hope for me,” she said sadly, “for Oz will
+not send me home until I have killed the Wicked Witch of the West; and
+that I can never do.”
+
+Her friends were sorry, but could do nothing to help her; so Dorothy
+went to her own room and lay down on the bed and cried herself to
+sleep.
+
+The next morning the soldier with the green whiskers came to the
+Scarecrow and said:
+
+“Come with me, for Oz has sent for you.”
+
+So the Scarecrow followed him and was admitted into the great Throne
+Room, where he saw, sitting in the emerald throne, a most lovely Lady.
+She was dressed in green silk gauze and wore upon her flowing green
+locks a crown of jewels. Growing from her shoulders were wings,
+gorgeous in color and so light that they fluttered if the slightest
+breath of air reached them.
+
+When the Scarecrow had bowed, as prettily as his straw stuffing would
+let him, before this beautiful creature, she looked upon him sweetly,
+and said:
+
+“I am Oz, the Great and Terrible. Who are you, and why do you seek me?”
+
+Now the Scarecrow, who had expected to see the great Head Dorothy had
+told him of, was much astonished; but he answered her bravely.
+
+“I am only a Scarecrow, stuffed with straw. Therefore I have no brains,
+and I come to you praying that you will put brains in my head instead
+of straw, so that I may become as much a man as any other in your
+dominions.”
+
+“Why should I do this for you?” asked the Lady.
+
+“Because you are wise and powerful, and no one else can help me,”
+answered the Scarecrow.
+
+“I never grant favors without some return,” said Oz; “but this much I
+will promise. If you will kill for me the Wicked Witch of the West, I
+will bestow upon you a great many brains, and such good brains that you
+will be the wisest man in all the Land of Oz.”
+
+“I thought you asked Dorothy to kill the Witch,” said the Scarecrow, in
+surprise.
+
+“So I did. I don’t care who kills her. But until she is dead I will not
+grant your wish. Now go, and do not seek me again until you have earned
+the brains you so greatly desire.”
+
+The Scarecrow went sorrowfully back to his friends and told them what
+Oz had said; and Dorothy was surprised to find that the Great Wizard
+was not a Head, as she had seen him, but a lovely Lady.
+
+“All the same,” said the Scarecrow, “she needs a heart as much as the
+Tin Woodman.”
+
+On the next morning the soldier with the green whiskers came to the Tin
+Woodman and said:
+
+“Oz has sent for you. Follow me.”
+
+So the Tin Woodman followed him and came to the great Throne Room. He
+did not know whether he would find Oz a lovely Lady or a Head, but he
+hoped it would be the lovely Lady. “For,” he said to himself, “if it is
+the head, I am sure I shall not be given a heart, since a head has no
+heart of its own and therefore cannot feel for me. But if it is the
+lovely Lady I shall beg hard for a heart, for all ladies are themselves
+said to be kindly hearted.”
+
+But when the Woodman entered the great Throne Room he saw neither the
+Head nor the Lady, for Oz had taken the shape of a most terrible Beast.
+It was nearly as big as an elephant, and the green throne seemed hardly
+strong enough to hold its weight. The Beast had a head like that of a
+rhinoceros, only there were five eyes in its face. There were five long
+arms growing out of its body, and it also had five long, slim legs.
+Thick, woolly hair covered every part of it, and a more
+dreadful-looking monster could not be imagined. It was fortunate the
+Tin Woodman had no heart at that moment, for it would have beat loud
+and fast from terror. But being only tin, the Woodman was not at all
+afraid, although he was much disappointed.
+
+“I am Oz, the Great and Terrible,” spoke the Beast, in a voice that was
+one great roar. “Who are you, and why do you seek me?”
+
+“I am a Woodman, and made of tin. Therefore I have no heart, and cannot
+love. I pray you to give me a heart that I may be as other men are.”
+
+“Why should I do this?” demanded the Beast.
+
+“Because I ask it, and you alone can grant my request,” answered the
+Woodman.
+
+Oz gave a low growl at this, but said, gruffly: “If you indeed desire a
+heart, you must earn it.”
+
+“How?” asked the Woodman.
+
+“Help Dorothy to kill the Wicked Witch of the West,” replied the Beast.
+“When the Witch is dead, come to me, and I will then give you the
+biggest and kindest and most loving heart in all the Land of Oz.”
+
+So the Tin Woodman was forced to return sorrowfully to his friends and
+tell them of the terrible Beast he had seen. They all wondered greatly
+at the many forms the Great Wizard could take upon himself, and the
+Lion said:
+
+“If he is a Beast when I go to see him, I shall roar my loudest, and so
+frighten him that he will grant all I ask. And if he is the lovely
+Lady, I shall pretend to spring upon her, and so compel her to do my
+bidding. And if he is the great Head, he will be at my mercy; for I
+will roll this head all about the room until he promises to give us
+what we desire. So be of good cheer, my friends, for all will yet be
+well.”
+
+The next morning the soldier with the green whiskers led the Lion to
+the great Throne Room and bade him enter the presence of Oz.
+
+The Lion at once passed through the door, and glancing around saw, to
+his surprise, that before the throne was a Ball of Fire, so fierce and
+glowing he could scarcely bear to gaze upon it. His first thought was
+that Oz had by accident caught on fire and was burning up; but when he
+tried to go nearer, the heat was so intense that it singed his
+whiskers, and he crept back tremblingly to a spot nearer the door.
+
+Then a low, quiet voice came from the Ball of Fire, and these were the
+words it spoke:
+
+“I am Oz, the Great and Terrible. Who are you, and why do you seek me?”
+
+And the Lion answered, “I am a Cowardly Lion, afraid of everything. I
+came to you to beg that you give me courage, so that in reality I may
+become the King of Beasts, as men call me.”
+
+“Why should I give you courage?” demanded Oz.
+
+“Because of all Wizards you are the greatest, and alone have power to
+grant my request,” answered the Lion.
+
+The Ball of Fire burned fiercely for a time, and the voice said, “Bring
+me proof that the Wicked Witch is dead, and that moment I will give you
+courage. But as long as the Witch lives, you must remain a coward.”
+
+The Lion was angry at this speech, but could say nothing in reply, and
+while he stood silently gazing at the Ball of Fire it became so
+furiously hot that he turned tail and rushed from the room. He was glad
+to find his friends waiting for him, and told them of his terrible
+interview with the Wizard.
+
+“What shall we do now?” asked Dorothy sadly.
+
+“There is only one thing we can do,” returned the Lion, “and that is to
+go to the land of the Winkies, seek out the Wicked Witch, and destroy
+her.”
+
+“But suppose we cannot?” said the girl.
+
+“Then I shall never have courage,” declared the Lion.
+
+“And I shall never have brains,” added the Scarecrow.
+
+“And I shall never have a heart,” spoke the Tin Woodman.
+
+“And I shall never see Aunt Em and Uncle Henry,” said Dorothy,
+beginning to cry.
+
+“Be careful!” cried the green girl. “The tears will fall on your green
+silk gown and spot it.”
+
+So Dorothy dried her eyes and said, “I suppose we must try it; but I am
+sure I do not want to kill anybody, even to see Aunt Em again.”
+
+“I will go with you; but I’m too much of a coward to kill the Witch,”
+said the Lion.
+
+“I will go too,” declared the Scarecrow; “but I shall not be of much
+help to you, I am such a fool.”
+
+“I haven’t the heart to harm even a Witch,” remarked the Tin Woodman;
+“but if you go I certainly shall go with you.”
+
+Therefore it was decided to start upon their journey the next morning,
+and the Woodman sharpened his axe on a green grindstone and had all his
+joints properly oiled. The Scarecrow stuffed himself with fresh straw
+and Dorothy put new paint on his eyes that he might see better. The
+green girl, who was very kind to them, filled Dorothy’s basket with
+good things to eat, and fastened a little bell around Toto’s neck with
+a green ribbon.
+
+They went to bed quite early and slept soundly until daylight, when
+they were awakened by the crowing of a green cock that lived in the
+back yard of the Palace, and the cackling of a hen that had laid a
+green egg.
+
+
+
+
+Chapter XII
+The Search for the Wicked Witch
+
+
+The soldier with the green whiskers led them through the streets of the
+Emerald City until they reached the room where the Guardian of the
+Gates lived. This officer unlocked their spectacles to put them back in
+his great box, and then he politely opened the gate for our friends.
+
+“Which road leads to the Wicked Witch of the West?” asked Dorothy.
+
+“There is no road,” answered the Guardian of the Gates. “No one ever
+wishes to go that way.”
+
+“How, then, are we to find her?” inquired the girl.
+
+“That will be easy,” replied the man, “for when she knows you are in
+the country of the Winkies she will find you, and make you all her
+slaves.”
+
+“Perhaps not,” said the Scarecrow, “for we mean to destroy her.”
+
+“Oh, that is different,” said the Guardian of the Gates. “No one has
+ever destroyed her before, so I naturally thought she would make slaves
+of you, as she has of the rest. But take care; for she is wicked and
+fierce, and may not allow you to destroy her. Keep to the West, where
+the sun sets, and you cannot fail to find her.”
+
+They thanked him and bade him good-bye, and turned toward the West,
+walking over fields of soft grass dotted here and there with daisies
+and buttercups. Dorothy still wore the pretty silk dress she had put on
+in the palace, but now, to her surprise, she found it was no longer
+green, but pure white. The ribbon around Toto’s neck had also lost its
+green color and was as white as Dorothy’s dress.
+
+The Emerald City was soon left far behind. As they advanced the ground
+became rougher and hillier, for there were no farms nor houses in this
+country of the West, and the ground was untilled.
+
+In the afternoon the sun shone hot in their faces, for there were no
+trees to offer them shade; so that before night Dorothy and Toto and
+the Lion were tired, and lay down upon the grass and fell asleep, with
+the Woodman and the Scarecrow keeping watch.
+
+Now the Wicked Witch of the West had but one eye, yet that was as
+powerful as a telescope, and could see everywhere. So, as she sat in
+the door of her castle, she happened to look around and saw Dorothy
+lying asleep, with her friends all about her. They were a long distance
+off, but the Wicked Witch was angry to find them in her country; so she
+blew upon a silver whistle that hung around her neck.
+
+At once there came running to her from all directions a pack of great
+wolves. They had long legs and fierce eyes and sharp teeth.
+
+“Go to those people,” said the Witch, “and tear them to pieces.”
+
+“Are you not going to make them your slaves?” asked the leader of the
+wolves.
+
+“No,” she answered, “one is of tin, and one of straw; one is a girl and
+another a Lion. None of them is fit to work, so you may tear them into
+small pieces.”
+
+“Very well,” said the wolf, and he dashed away at full speed, followed
+by the others.
+
+It was lucky the Scarecrow and the Woodman were wide awake and heard
+the wolves coming.
+
+“This is my fight,” said the Woodman, “so get behind me and I will meet
+them as they come.”
+
+He seized his axe, which he had made very sharp, and as the leader of
+the wolves came on the Tin Woodman swung his arm and chopped the wolf’s
+head from its body, so that it immediately died. As soon as he could
+raise his axe another wolf came up, and he also fell under the sharp
+edge of the Tin Woodman’s weapon. There were forty wolves, and forty
+times a wolf was killed, so that at last they all lay dead in a heap
+before the Woodman.
+
+Then he put down his axe and sat beside the Scarecrow, who said, “It
+was a good fight, friend.”
+
+They waited until Dorothy awoke the next morning. The little girl was
+quite frightened when she saw the great pile of shaggy wolves, but the
+Tin Woodman told her all. She thanked him for saving them and sat down
+to breakfast, after which they started again upon their journey.
+
+Now this same morning the Wicked Witch came to the door of her castle
+and looked out with her one eye that could see far off. She saw all her
+wolves lying dead, and the strangers still traveling through her
+country. This made her angrier than before, and she blew her silver
+whistle twice.
+
+Straightway a great flock of wild crows came flying toward her, enough
+to darken the sky.
+
+And the Wicked Witch said to the King Crow, “Fly at once to the
+strangers; peck out their eyes and tear them to pieces.”
+
+The wild crows flew in one great flock toward Dorothy and her
+companions. When the little girl saw them coming she was afraid.
+
+But the Scarecrow said, “This is my battle, so lie down beside me and
+you will not be harmed.”
+
+So they all lay upon the ground except the Scarecrow, and he stood up
+and stretched out his arms. And when the crows saw him they were
+frightened, as these birds always are by scarecrows, and did not dare
+to come any nearer. But the King Crow said:
+
+“It is only a stuffed man. I will peck his eyes out.”
+
+The King Crow flew at the Scarecrow, who caught it by the head and
+twisted its neck until it died. And then another crow flew at him, and
+the Scarecrow twisted its neck also. There were forty crows, and forty
+times the Scarecrow twisted a neck, until at last all were lying dead
+beside him. Then he called to his companions to rise, and again they
+went upon their journey.
+
+When the Wicked Witch looked out again and saw all her crows lying in a
+heap, she got into a terrible rage, and blew three times upon her
+silver whistle.
+
+Forthwith there was heard a great buzzing in the air, and a swarm of
+black bees came flying toward her.
+
+“Go to the strangers and sting them to death!” commanded the Witch, and
+the bees turned and flew rapidly until they came to where Dorothy and
+her friends were walking. But the Woodman had seen them coming, and the
+Scarecrow had decided what to do.
+
+“Take out my straw and scatter it over the little girl and the dog and
+the Lion,” he said to the Woodman, “and the bees cannot sting them.”
+This the Woodman did, and as Dorothy lay close beside the Lion and held
+Toto in her arms, the straw covered them entirely.
+
+The bees came and found no one but the Woodman to sting, so they flew
+at him and broke off all their stings against the tin, without hurting
+the Woodman at all. And as bees cannot live when their stings are
+broken that was the end of the black bees, and they lay scattered thick
+about the Woodman, like little heaps of fine coal.
+
+Then Dorothy and the Lion got up, and the girl helped the Tin Woodman
+put the straw back into the Scarecrow again, until he was as good as
+ever. So they started upon their journey once more.
+
+The Wicked Witch was so angry when she saw her black bees in little
+heaps like fine coal that she stamped her foot and tore her hair and
+gnashed her teeth. And then she called a dozen of her slaves, who were
+the Winkies, and gave them sharp spears, telling them to go to the
+strangers and destroy them.
+
+The Winkies were not a brave people, but they had to do as they were
+told. So they marched away until they came near to Dorothy. Then the
+Lion gave a great roar and sprang towards them, and the poor Winkies
+were so frightened that they ran back as fast as they could.
+
+When they returned to the castle the Wicked Witch beat them well with a
+strap, and sent them back to their work, after which she sat down to
+think what she should do next. She could not understand how all her
+plans to destroy these strangers had failed; but she was a powerful
+Witch, as well as a wicked one, and she soon made up her mind how to
+act.
+
+There was, in her cupboard, a Golden Cap, with a circle of diamonds and
+rubies running round it. This Golden Cap had a charm. Whoever owned it
+could call three times upon the Winged Monkeys, who would obey any
+order they were given. But no person could command these strange
+creatures more than three times. Twice already the Wicked Witch had
+used the charm of the Cap. Once was when she had made the Winkies her
+slaves, and set herself to rule over their country. The Winged Monkeys
+had helped her do this. The second time was when she had fought against
+the Great Oz himself, and driven him out of the land of the West. The
+Winged Monkeys had also helped her in doing this. Only once more could
+she use this Golden Cap, for which reason she did not like to do so
+until all her other powers were exhausted. But now that her fierce
+wolves and her wild crows and her stinging bees were gone, and her
+slaves had been scared away by the Cowardly Lion, she saw there was
+only one way left to destroy Dorothy and her friends.
+
+So the Wicked Witch took the Golden Cap from her cupboard and placed it
+upon her head. Then she stood upon her left foot and said slowly:
+
+“Ep-pe, pep-pe, kak-ke!”
+
+Next she stood upon her right foot and said:
+
+“Hil-lo, hol-lo, hel-lo!”
+
+After this she stood upon both feet and cried in a loud voice:
+
+“Ziz-zy, zuz-zy, zik!”
+
+Now the charm began to work. The sky was darkened, and a low rumbling
+sound was heard in the air. There was a rushing of many wings, a great
+chattering and laughing, and the sun came out of the dark sky to show
+the Wicked Witch surrounded by a crowd of monkeys, each with a pair of
+immense and powerful wings on his shoulders.
+
+One, much bigger than the others, seemed to be their leader. He flew
+close to the Witch and said, “You have called us for the third and last
+time. What do you command?”
+
+“Go to the strangers who are within my land and destroy them all except
+the Lion,” said the Wicked Witch. “Bring that beast to me, for I have a
+mind to harness him like a horse, and make him work.”
+
+“Your commands shall be obeyed,” said the leader. Then, with a great
+deal of chattering and noise, the Winged Monkeys flew away to the place
+where Dorothy and her friends were walking.
+
+Some of the Monkeys seized the Tin Woodman and carried him through the
+air until they were over a country thickly covered with sharp rocks.
+Here they dropped the poor Woodman, who fell a great distance to the
+rocks, where he lay so battered and dented that he could neither move
+nor groan.
+
+Others of the Monkeys caught the Scarecrow, and with their long fingers
+pulled all of the straw out of his clothes and head. They made his hat
+and boots and clothes into a small bundle and threw it into the top
+branches of a tall tree.
+
+The remaining Monkeys threw pieces of stout rope around the Lion and
+wound many coils about his body and head and legs, until he was unable
+to bite or scratch or struggle in any way. Then they lifted him up and
+flew away with him to the Witch’s castle, where he was placed in a
+small yard with a high iron fence around it, so that he could not
+escape.
+
+But Dorothy they did not harm at all. She stood, with Toto in her arms,
+watching the sad fate of her comrades and thinking it would soon be her
+turn. The leader of the Winged Monkeys flew up to her, his long, hairy
+arms stretched out and his ugly face grinning terribly; but he saw the
+mark of the Good Witch’s kiss upon her forehead and stopped short,
+motioning the others not to touch her.
+
+“We dare not harm this little girl,” he said to them, “for she is
+protected by the Power of Good, and that is greater than the Power of
+Evil. All we can do is to carry her to the castle of the Wicked Witch
+and leave her there.”
+
+So, carefully and gently, they lifted Dorothy in their arms and carried
+her swiftly through the air until they came to the castle, where they
+set her down upon the front doorstep. Then the leader said to the
+Witch:
+
+“We have obeyed you as far as we were able. The Tin Woodman and the
+Scarecrow are destroyed, and the Lion is tied up in your yard. The
+little girl we dare not harm, nor the dog she carries in her arms. Your
+power over our band is now ended, and you will never see us again.”
+
+Then all the Winged Monkeys, with much laughing and chattering and
+noise, flew into the air and were soon out of sight.
+
+The Wicked Witch was both surprised and worried when she saw the mark
+on Dorothy’s forehead, for she knew well that neither the Winged
+Monkeys nor she, herself, dare hurt the girl in any way. She looked
+down at Dorothy’s feet, and seeing the Silver Shoes, began to tremble
+with fear, for she knew what a powerful charm belonged to them. At
+first the Witch was tempted to run away from Dorothy; but she happened
+to look into the child’s eyes and saw how simple the soul behind them
+was, and that the little girl did not know of the wonderful power the
+Silver Shoes gave her. So the Wicked Witch laughed to herself, and
+thought, “I can still make her my slave, for she does not know how to
+use her power.” Then she said to Dorothy, harshly and severely:
+
+“Come with me; and see that you mind everything I tell you, for if you
+do not I will make an end of you, as I did of the Tin Woodman and the
+Scarecrow.”
+
+Dorothy followed her through many of the beautiful rooms in her castle
+until they came to the kitchen, where the Witch bade her clean the pots
+and kettles and sweep the floor and keep the fire fed with wood.
+
+Dorothy went to work meekly, with her mind made up to work as hard as
+she could; for she was glad the Wicked Witch had decided not to kill
+her.
+
+With Dorothy hard at work, the Witch thought she would go into the
+courtyard and harness the Cowardly Lion like a horse; it would amuse
+her, she was sure, to make him draw her chariot whenever she wished to
+go to drive. But as she opened the gate the Lion gave a loud roar and
+bounded at her so fiercely that the Witch was afraid, and ran out and
+shut the gate again.
+
+“If I cannot harness you,” said the Witch to the Lion, speaking through
+the bars of the gate, “I can starve you. You shall have nothing to eat
+until you do as I wish.”
+
+So after that she took no food to the imprisoned Lion; but every day
+she came to the gate at noon and asked, “Are you ready to be harnessed
+like a horse?”
+
+And the Lion would answer, “No. If you come in this yard, I will bite
+you.”
+
+The reason the Lion did not have to do as the Witch wished was that
+every night, while the woman was asleep, Dorothy carried him food from
+the cupboard. After he had eaten he would lie down on his bed of straw,
+and Dorothy would lie beside him and put her head on his soft, shaggy
+mane, while they talked of their troubles and tried to plan some way to
+escape. But they could find no way to get out of the castle, for it was
+constantly guarded by the yellow Winkies, who were the slaves of the
+Wicked Witch and too afraid of her not to do as she told them.
+
+The girl had to work hard during the day, and often the Witch
+threatened to beat her with the same old umbrella she always carried in
+her hand. But, in truth, she did not dare to strike Dorothy, because of
+the mark upon her forehead. The child did not know this, and was full
+of fear for herself and Toto. Once the Witch struck Toto a blow with
+her umbrella and the brave little dog flew at her and bit her leg in
+return. The Witch did not bleed where she was bitten, for she was so
+wicked that the blood in her had dried up many years before.
+
+Dorothy’s life became very sad as she grew to understand that it would
+be harder than ever to get back to Kansas and Aunt Em again. Sometimes
+she would cry bitterly for hours, with Toto sitting at her feet and
+looking into her face, whining dismally to show how sorry he was for
+his little mistress. Toto did not really care whether he was in Kansas
+or the Land of Oz so long as Dorothy was with him; but he knew the
+little girl was unhappy, and that made him unhappy too.
+
+Now the Wicked Witch had a great longing to have for her own the Silver
+Shoes which the girl always wore. Her bees and her crows and her wolves
+were lying in heaps and drying up, and she had used up all the power of
+the Golden Cap; but if she could only get hold of the Silver Shoes,
+they would give her more power than all the other things she had lost.
+She watched Dorothy carefully, to see if she ever took off her shoes,
+thinking she might steal them. But the child was so proud of her pretty
+shoes that she never took them off except at night and when she took
+her bath. The Witch was too much afraid of the dark to dare go in
+Dorothy’s room at night to take the shoes, and her dread of water was
+greater than her fear of the dark, so she never came near when Dorothy
+was bathing. Indeed, the old Witch never touched water, nor ever let
+water touch her in any way.
+
+But the wicked creature was very cunning, and she finally thought of a
+trick that would give her what she wanted. She placed a bar of iron in
+the middle of the kitchen floor, and then by her magic arts made the
+iron invisible to human eyes. So that when Dorothy walked across the
+floor she stumbled over the bar, not being able to see it, and fell at
+full length. She was not much hurt, but in her fall one of the Silver
+Shoes came off; and before she could reach it, the Witch had snatched
+it away and put it on her own skinny foot.
+
+The wicked woman was greatly pleased with the success of her trick, for
+as long as she had one of the shoes she owned half the power of their
+charm, and Dorothy could not use it against her, even had she known how
+to do so.
+
+The little girl, seeing she had lost one of her pretty shoes, grew
+angry, and said to the Witch, “Give me back my shoe!”
+
+“I will not,” retorted the Witch, “for it is now my shoe, and not
+yours.”
+
+“You are a wicked creature!” cried Dorothy. “You have no right to take
+my shoe from me.”
+
+“I shall keep it, just the same,” said the Witch, laughing at her, “and
+someday I shall get the other one from you, too.”
+
+This made Dorothy so very angry that she picked up the bucket of water
+that stood near and dashed it over the Witch, wetting her from head to
+foot.
+
+Instantly the wicked woman gave a loud cry of fear, and then, as
+Dorothy looked at her in wonder, the Witch began to shrink and fall
+away.
+
+“See what you have done!” she screamed. “In a minute I shall melt
+away.”
+
+“I’m very sorry, indeed,” said Dorothy, who was truly frightened to see
+the Witch actually melting away like brown sugar before her very eyes.
+
+“Didn’t you know water would be the end of me?” asked the Witch, in a
+wailing, despairing voice.
+
+“Of course not,” answered Dorothy. “How should I?”
+
+“Well, in a few minutes I shall be all melted, and you will have the
+castle to yourself. I have been wicked in my day, but I never thought a
+little girl like you would ever be able to melt me and end my wicked
+deeds. Look out—here I go!”
+
+With these words the Witch fell down in a brown, melted, shapeless mass
+and began to spread over the clean boards of the kitchen floor. Seeing
+that she had really melted away to nothing, Dorothy drew another bucket
+of water and threw it over the mess. She then swept it all out the
+door. After picking out the silver shoe, which was all that was left of
+the old woman, she cleaned and dried it with a cloth, and put it on her
+foot again. Then, being at last free to do as she chose, she ran out to
+the courtyard to tell the Lion that the Wicked Witch of the West had
+come to an end, and that they were no longer prisoners in a strange
+land.
+
+
+
+
+Chapter XIII
+The Rescue
+
+
+The Cowardly Lion was much pleased to hear that the Wicked Witch had
+been melted by a bucket of water, and Dorothy at once unlocked the gate
+of his prison and set him free. They went in together to the castle,
+where Dorothy’s first act was to call all the Winkies together and tell
+them that they were no longer slaves.
+
+There was great rejoicing among the yellow Winkies, for they had been
+made to work hard during many years for the Wicked Witch, who had
+always treated them with great cruelty. They kept this day as a
+holiday, then and ever after, and spent the time in feasting and
+dancing.
+
+“If our friends, the Scarecrow and the Tin Woodman, were only with us,”
+said the Lion, “I should be quite happy.”
+
+“Don’t you suppose we could rescue them?” asked the girl anxiously.
+
+“We can try,” answered the Lion.
+
+So they called the yellow Winkies and asked them if they would help to
+rescue their friends, and the Winkies said that they would be delighted
+to do all in their power for Dorothy, who had set them free from
+bondage. So she chose a number of the Winkies who looked as if they
+knew the most, and they all started away. They traveled that day and
+part of the next until they came to the rocky plain where the Tin
+Woodman lay, all battered and bent. His axe was near him, but the blade
+was rusted and the handle broken off short.
+
+The Winkies lifted him tenderly in their arms, and carried him back to
+the Yellow Castle again, Dorothy shedding a few tears by the way at the
+sad plight of her old friend, and the Lion looking sober and sorry.
+When they reached the castle Dorothy said to the Winkies:
+
+“Are any of your people tinsmiths?”
+
+“Oh, yes. Some of us are very good tinsmiths,” they told her.
+
+“Then bring them to me,” she said. And when the tinsmiths came,
+bringing with them all their tools in baskets, she inquired, “Can you
+straighten out those dents in the Tin Woodman, and bend him back into
+shape again, and solder him together where he is broken?”
+
+The tinsmiths looked the Woodman over carefully and then answered that
+they thought they could mend him so he would be as good as ever. So
+they set to work in one of the big yellow rooms of the castle and
+worked for three days and four nights, hammering and twisting and
+bending and soldering and polishing and pounding at the legs and body
+and head of the Tin Woodman, until at last he was straightened out into
+his old form, and his joints worked as well as ever. To be sure, there
+were several patches on him, but the tinsmiths did a good job, and as
+the Woodman was not a vain man he did not mind the patches at all.
+
+When, at last, he walked into Dorothy’s room and thanked her for
+rescuing him, he was so pleased that he wept tears of joy, and Dorothy
+had to wipe every tear carefully from his face with her apron, so his
+joints would not be rusted. At the same time her own tears fell thick
+and fast at the joy of meeting her old friend again, and these tears
+did not need to be wiped away. As for the Lion, he wiped his eyes so
+often with the tip of his tail that it became quite wet, and he was
+obliged to go out into the courtyard and hold it in the sun till it
+dried.
+
+“If we only had the Scarecrow with us again,” said the Tin Woodman,
+when Dorothy had finished telling him everything that had happened, “I
+should be quite happy.”
+
+“We must try to find him,” said the girl.
+
+So she called the Winkies to help her, and they walked all that day and
+part of the next until they came to the tall tree in the branches of
+which the Winged Monkeys had tossed the Scarecrow’s clothes.
+
+It was a very tall tree, and the trunk was so smooth that no one could
+climb it; but the Woodman said at once, “I’ll chop it down, and then we
+can get the Scarecrow’s clothes.”
+
+Now while the tinsmiths had been at work mending the Woodman himself,
+another of the Winkies, who was a goldsmith, had made an axe-handle of
+solid gold and fitted it to the Woodman’s axe, instead of the old
+broken handle. Others polished the blade until all the rust was removed
+and it glistened like burnished silver.
+
+As soon as he had spoken, the Tin Woodman began to chop, and in a short
+time the tree fell over with a crash, whereupon the Scarecrow’s clothes
+fell out of the branches and rolled off on the ground.
+
+Dorothy picked them up and had the Winkies carry them back to the
+castle, where they were stuffed with nice, clean straw; and behold!
+here was the Scarecrow, as good as ever, thanking them over and over
+again for saving him.
+
+Now that they were reunited, Dorothy and her friends spent a few happy
+days at the Yellow Castle, where they found everything they needed to
+make them comfortable.
+
+But one day the girl thought of Aunt Em, and said, “We must go back to
+Oz, and claim his promise.”
+
+“Yes,” said the Woodman, “at last I shall get my heart.”
+
+“And I shall get my brains,” added the Scarecrow joyfully.
+
+“And I shall get my courage,” said the Lion thoughtfully.
+
+“And I shall get back to Kansas,” cried Dorothy, clapping her hands.
+“Oh, let us start for the Emerald City tomorrow!”
+
+This they decided to do. The next day they called the Winkies together
+and bade them good-bye. The Winkies were sorry to have them go, and
+they had grown so fond of the Tin Woodman that they begged him to stay
+and rule over them and the Yellow Land of the West. Finding they were
+determined to go, the Winkies gave Toto and the Lion each a golden
+collar; and to Dorothy they presented a beautiful bracelet studded with
+diamonds; and to the Scarecrow they gave a gold-headed walking stick,
+to keep him from stumbling; and to the Tin Woodman they offered a
+silver oil-can, inlaid with gold and set with precious jewels.
+
+Every one of the travelers made the Winkies a pretty speech in return,
+and all shook hands with them until their arms ached.
+
+Dorothy went to the Witch’s cupboard to fill her basket with food for
+the journey, and there she saw the Golden Cap. She tried it on her own
+head and found that it fitted her exactly. She did not know anything
+about the charm of the Golden Cap, but she saw that it was pretty, so
+she made up her mind to wear it and carry her sunbonnet in the basket.
+
+Then, being prepared for the journey, they all started for the Emerald
+City; and the Winkies gave them three cheers and many good wishes to
+carry with them.
+
+
+
+
+Chapter XIV
+The Winged Monkeys
+
+
+You will remember there was no road—not even a pathway—between the
+castle of the Wicked Witch and the Emerald City. When the four
+travelers went in search of the Witch she had seen them coming, and so
+sent the Winged Monkeys to bring them to her. It was much harder to
+find their way back through the big fields of buttercups and yellow
+daisies than it was being carried. They knew, of course, they must go
+straight east, toward the rising sun; and they started off in the right
+way. But at noon, when the sun was over their heads, they did not know
+which was east and which was west, and that was the reason they were
+lost in the great fields. They kept on walking, however, and at night
+the moon came out and shone brightly. So they lay down among the sweet
+smelling yellow flowers and slept soundly until morning—all but the
+Scarecrow and the Tin Woodman.
+
+The next morning the sun was behind a cloud, but they started on, as if
+they were quite sure which way they were going.
+
+“If we walk far enough,” said Dorothy, “I am sure we shall sometime
+come to some place.”
+
+But day by day passed away, and they still saw nothing before them but
+the scarlet fields. The Scarecrow began to grumble a bit.
+
+“We have surely lost our way,” he said, “and unless we find it again in
+time to reach the Emerald City, I shall never get my brains.”
+
+“Nor I my heart,” declared the Tin Woodman. “It seems to me I can
+scarcely wait till I get to Oz, and you must admit this is a very long
+journey.”
+
+“You see,” said the Cowardly Lion, with a whimper, “I haven’t the
+courage to keep tramping forever, without getting anywhere at all.”
+
+Then Dorothy lost heart. She sat down on the grass and looked at her
+companions, and they sat down and looked at her, and Toto found that
+for the first time in his life he was too tired to chase a butterfly
+that flew past his head. So he put out his tongue and panted and looked
+at Dorothy as if to ask what they should do next.
+
+“Suppose we call the field mice,” she suggested. “They could probably
+tell us the way to the Emerald City.”
+
+“To be sure they could,” cried the Scarecrow. “Why didn’t we think of
+that before?”
+
+Dorothy blew the little whistle she had always carried about her neck
+since the Queen of the Mice had given it to her. In a few minutes they
+heard the pattering of tiny feet, and many of the small gray mice came
+running up to her. Among them was the Queen herself, who asked, in her
+squeaky little voice:
+
+“What can I do for my friends?”
+
+“We have lost our way,” said Dorothy. “Can you tell us where the
+Emerald City is?”
+
+“Certainly,” answered the Queen; “but it is a great way off, for you
+have had it at your backs all this time.” Then she noticed Dorothy’s
+Golden Cap, and said, “Why don’t you use the charm of the Cap, and call
+the Winged Monkeys to you? They will carry you to the City of Oz in
+less than an hour.”
+
+“I didn’t know there was a charm,” answered Dorothy, in surprise. “What
+is it?”
+
+“It is written inside the Golden Cap,” replied the Queen of the Mice.
+“But if you are going to call the Winged Monkeys we must run away, for
+they are full of mischief and think it great fun to plague us.”
+
+“Won’t they hurt me?” asked the girl anxiously.
+
+“Oh, no. They must obey the wearer of the Cap. Good-bye!” And she
+scampered out of sight, with all the mice hurrying after her.
+
+Dorothy looked inside the Golden Cap and saw some words written upon
+the lining. These, she thought, must be the charm, so she read the
+directions carefully and put the Cap upon her head.
+
+“Ep-pe, pep-pe, kak-ke!” she said, standing on her left foot.
+
+“What did you say?” asked the Scarecrow, who did not know what she was
+doing.
+
+“Hil-lo, hol-lo, hel-lo!” Dorothy went on, standing this time on her
+right foot.
+
+“Hello!” replied the Tin Woodman calmly.
+
+“Ziz-zy, zuz-zy, zik!” said Dorothy, who was now standing on both feet.
+This ended the saying of the charm, and they heard a great chattering
+and flapping of wings, as the band of Winged Monkeys flew up to them.
+
+The King bowed low before Dorothy, and asked, “What is your command?”
+
+“We wish to go to the Emerald City,” said the child, “and we have lost
+our way.”
+
+“We will carry you,” replied the King, and no sooner had he spoken than
+two of the Monkeys caught Dorothy in their arms and flew away with her.
+Others took the Scarecrow and the Woodman and the Lion, and one little
+Monkey seized Toto and flew after them, although the dog tried hard to
+bite him.
+
+The Scarecrow and the Tin Woodman were rather frightened at first, for
+they remembered how badly the Winged Monkeys had treated them before;
+but they saw that no harm was intended, so they rode through the air
+quite cheerfully, and had a fine time looking at the pretty gardens and
+woods far below them.
+
+Dorothy found herself riding easily between two of the biggest Monkeys,
+one of them the King himself. They had made a chair of their hands and
+were careful not to hurt her.
+
+“Why do you have to obey the charm of the Golden Cap?” she asked.
+
+“That is a long story,” answered the King, with a winged laugh; “but as
+we have a long journey before us, I will pass the time by telling you
+about it, if you wish.”
+
+“I shall be glad to hear it,” she replied.
+
+“Once,” began the leader, “we were a free people, living happily in the
+great forest, flying from tree to tree, eating nuts and fruit, and
+doing just as we pleased without calling anybody master. Perhaps some
+of us were rather too full of mischief at times, flying down to pull
+the tails of the animals that had no wings, chasing birds, and throwing
+nuts at the people who walked in the forest. But we were careless and
+happy and full of fun, and enjoyed every minute of the day. This was
+many years ago, long before Oz came out of the clouds to rule over this
+land.
+
+“There lived here then, away at the North, a beautiful princess, who
+was also a powerful sorceress. All her magic was used to help the
+people, and she was never known to hurt anyone who was good. Her name
+was Gayelette, and she lived in a handsome palace built from great
+blocks of ruby. Everyone loved her, but her greatest sorrow was that
+she could find no one to love in return, since all the men were much
+too stupid and ugly to mate with one so beautiful and wise. At last,
+however, she found a boy who was handsome and manly and wise beyond his
+years. Gayelette made up her mind that when he grew to be a man she
+would make him her husband, so she took him to her ruby palace and used
+all her magic powers to make him as strong and good and lovely as any
+woman could wish. When he grew to manhood, Quelala, as he was called,
+was said to be the best and wisest man in all the land, while his manly
+beauty was so great that Gayelette loved him dearly, and hastened to
+make everything ready for the wedding.
+
+“My grandfather was at that time the King of the Winged Monkeys which
+lived in the forest near Gayelette’s palace, and the old fellow loved a
+joke better than a good dinner. One day, just before the wedding, my
+grandfather was flying out with his band when he saw Quelala walking
+beside the river. He was dressed in a rich costume of pink silk and
+purple velvet, and my grandfather thought he would see what he could
+do. At his word the band flew down and seized Quelala, carried him in
+their arms until they were over the middle of the river, and then
+dropped him into the water.
+
+“‘Swim out, my fine fellow,’ cried my grandfather, ‘and see if the
+water has spotted your clothes.’ Quelala was much too wise not to swim,
+and he was not in the least spoiled by all his good fortune. He
+laughed, when he came to the top of the water, and swam in to shore.
+But when Gayelette came running out to him she found his silks and
+velvet all ruined by the river.
+
+“The princess was angry, and she knew, of course, who did it. She had
+all the Winged Monkeys brought before her, and she said at first that
+their wings should be tied and they should be treated as they had
+treated Quelala, and dropped in the river. But my grandfather pleaded
+hard, for he knew the Monkeys would drown in the river with their wings
+tied, and Quelala said a kind word for them also; so that Gayelette
+finally spared them, on condition that the Winged Monkeys should ever
+after do three times the bidding of the owner of the Golden Cap. This
+Cap had been made for a wedding present to Quelala, and it is said to
+have cost the princess half her kingdom. Of course my grandfather and
+all the other Monkeys at once agreed to the condition, and that is how
+it happens that we are three times the slaves of the owner of the
+Golden Cap, whosoever he may be.”
+
+“And what became of them?” asked Dorothy, who had been greatly
+interested in the story.
+
+“Quelala being the first owner of the Golden Cap,” replied the Monkey,
+“he was the first to lay his wishes upon us. As his bride could not
+bear the sight of us, he called us all to him in the forest after he
+had married her and ordered us always to keep where she could never
+again set eyes on a Winged Monkey, which we were glad to do, for we
+were all afraid of her.
+
+“This was all we ever had to do until the Golden Cap fell into the
+hands of the Wicked Witch of the West, who made us enslave the Winkies,
+and afterward drive Oz himself out of the Land of the West. Now the
+Golden Cap is yours, and three times you have the right to lay your
+wishes upon us.”
+
+As the Monkey King finished his story Dorothy looked down and saw the
+green, shining walls of the Emerald City before them. She wondered at
+the rapid flight of the Monkeys, but was glad the journey was over. The
+strange creatures set the travelers down carefully before the gate of
+the City, the King bowed low to Dorothy, and then flew swiftly away,
+followed by all his band.
+
+“That was a good ride,” said the little girl.
+
+“Yes, and a quick way out of our troubles,” replied the Lion. “How
+lucky it was you brought away that wonderful Cap!”
+
+
+
+
+Chapter XV
+The Discovery of Oz, the Terrible
+
+
+The four travelers walked up to the great gate of Emerald City and rang
+the bell. After ringing several times, it was opened by the same
+Guardian of the Gates they had met before.
+
+“What! are you back again?” he asked, in surprise.
+
+“Do you not see us?” answered the Scarecrow.
+
+“But I thought you had gone to visit the Wicked Witch of the West.”
+
+“We did visit her,” said the Scarecrow.
+
+“And she let you go again?” asked the man, in wonder.
+
+“She could not help it, for she is melted,” explained the Scarecrow.
+
+“Melted! Well, that is good news, indeed,” said the man. “Who melted
+her?”
+
+“It was Dorothy,” said the Lion gravely.
+
+“Good gracious!” exclaimed the man, and he bowed very low indeed before
+her.
+
+Then he led them into his little room and locked the spectacles from
+the great box on all their eyes, just as he had done before. Afterward
+they passed on through the gate into the Emerald City. When the people
+heard from the Guardian of the Gates that Dorothy had melted the Wicked
+Witch of the West, they all gathered around the travelers and followed
+them in a great crowd to the Palace of Oz.
+
+The soldier with the green whiskers was still on guard before the door,
+but he let them in at once, and they were again met by the beautiful
+green girl, who showed each of them to their old rooms at once, so they
+might rest until the Great Oz was ready to receive them.
+
+The soldier had the news carried straight to Oz that Dorothy and the
+other travelers had come back again, after destroying the Wicked Witch;
+but Oz made no reply. They thought the Great Wizard would send for them
+at once, but he did not. They had no word from him the next day, nor
+the next, nor the next. The waiting was tiresome and wearing, and at
+last they grew vexed that Oz should treat them in so poor a fashion,
+after sending them to undergo hardships and slavery. So the Scarecrow
+at last asked the green girl to take another message to Oz, saying if
+he did not let them in to see him at once they would call the Winged
+Monkeys to help them, and find out whether he kept his promises or not.
+When the Wizard was given this message he was so frightened that he
+sent word for them to come to the Throne Room at four minutes after
+nine o’clock the next morning. He had once met the Winged Monkeys in
+the Land of the West, and he did not wish to meet them again.
+
+The four travelers passed a sleepless night, each thinking of the gift
+Oz had promised to bestow on him. Dorothy fell asleep only once, and
+then she dreamed she was in Kansas, where Aunt Em was telling her how
+glad she was to have her little girl at home again.
+
+Promptly at nine o’clock the next morning the green-whiskered soldier
+came to them, and four minutes later they all went into the Throne Room
+of the Great Oz.
+
+Of course each one of them expected to see the Wizard in the shape he
+had taken before, and all were greatly surprised when they looked about
+and saw no one at all in the room. They kept close to the door and
+closer to one another, for the stillness of the empty room was more
+dreadful than any of the forms they had seen Oz take.
+
+Presently they heard a solemn Voice, that seemed to come from somewhere
+near the top of the great dome, and it said:
+
+“I am Oz, the Great and Terrible. Why do you seek me?”
+
+They looked again in every part of the room, and then, seeing no one,
+Dorothy asked, “Where are you?”
+
+“I am everywhere,” answered the Voice, “but to the eyes of common
+mortals I am invisible. I will now seat myself upon my throne, that you
+may converse with me.” Indeed, the Voice seemed just then to come
+straight from the throne itself; so they walked toward it and stood in
+a row while Dorothy said:
+
+“We have come to claim our promise, O Oz.”
+
+“What promise?” asked Oz.
+
+“You promised to send me back to Kansas when the Wicked Witch was
+destroyed,” said the girl.
+
+“And you promised to give me brains,” said the Scarecrow.
+
+“And you promised to give me a heart,” said the Tin Woodman.
+
+“And you promised to give me courage,” said the Cowardly Lion.
+
+“Is the Wicked Witch really destroyed?” asked the Voice, and Dorothy
+thought it trembled a little.
+
+“Yes,” she answered, “I melted her with a bucket of water.”
+
+“Dear me,” said the Voice, “how sudden! Well, come to me tomorrow, for
+I must have time to think it over.”
+
+“You’ve had plenty of time already,” said the Tin Woodman angrily.
+
+“We shan’t wait a day longer,” said the Scarecrow.
+
+“You must keep your promises to us!” exclaimed Dorothy.
+
+The Lion thought it might be as well to frighten the Wizard, so he gave
+a large, loud roar, which was so fierce and dreadful that Toto jumped
+away from him in alarm and tipped over the screen that stood in a
+corner. As it fell with a crash they looked that way, and the next
+moment all of them were filled with wonder. For they saw, standing in
+just the spot the screen had hidden, a little old man, with a bald head
+and a wrinkled face, who seemed to be as much surprised as they were.
+The Tin Woodman, raising his axe, rushed toward the little man and
+cried out, “Who are you?”
+
+“I am Oz, the Great and Terrible,” said the little man, in a trembling
+voice. “But don’t strike me—please don’t—and I’ll do anything you want
+me to.”
+
+Our friends looked at him in surprise and dismay.
+
+“I thought Oz was a great Head,” said Dorothy.
+
+“And I thought Oz was a lovely Lady,” said the Scarecrow.
+
+“And I thought Oz was a terrible Beast,” said the Tin Woodman.
+
+“And I thought Oz was a Ball of Fire,” exclaimed the Lion.
+
+“No, you are all wrong,” said the little man meekly. “I have been
+making believe.”
+
+“Making believe!” cried Dorothy. “Are you not a Great Wizard?”
+
+“Hush, my dear,” he said. “Don’t speak so loud, or you will be
+overheard—and I should be ruined. I’m supposed to be a Great Wizard.”
+
+“And aren’t you?” she asked.
+
+“Not a bit of it, my dear; I’m just a common man.”
+
+“You’re more than that,” said the Scarecrow, in a grieved tone; “you’re
+a humbug.”
+
+“Exactly so!” declared the little man, rubbing his hands together as if
+it pleased him. “I am a humbug.”
+
+“But this is terrible,” said the Tin Woodman. “How shall I ever get my
+heart?”
+
+“Or I my courage?” asked the Lion.
+
+“Or I my brains?” wailed the Scarecrow, wiping the tears from his eyes
+with his coat sleeve.
+
+“My dear friends,” said Oz, “I pray you not to speak of these little
+things. Think of me, and the terrible trouble I’m in at being found
+out.”
+
+“Doesn’t anyone else know you’re a humbug?” asked Dorothy.
+
+“No one knows it but you four—and myself,” replied Oz. “I have fooled
+everyone so long that I thought I should never be found out. It was a
+great mistake my ever letting you into the Throne Room. Usually I will
+not see even my subjects, and so they believe I am something terrible.”
+
+“But, I don’t understand,” said Dorothy, in bewilderment. “How was it
+that you appeared to me as a great Head?”
+
+“That was one of my tricks,” answered Oz. “Step this way, please, and I
+will tell you all about it.”
+
+He led the way to a small chamber in the rear of the Throne Room, and
+they all followed him. He pointed to one corner, in which lay the great
+Head, made out of many thicknesses of paper, and with a carefully
+painted face.
+
+“This I hung from the ceiling by a wire,” said Oz. “I stood behind the
+screen and pulled a thread, to make the eyes move and the mouth open.”
+
+“But how about the voice?” she inquired.
+
+“Oh, I am a ventriloquist,” said the little man. “I can throw the sound
+of my voice wherever I wish, so that you thought it was coming out of
+the Head. Here are the other things I used to deceive you.” He showed
+the Scarecrow the dress and the mask he had worn when he seemed to be
+the lovely Lady. And the Tin Woodman saw that his terrible Beast was
+nothing but a lot of skins, sewn together, with slats to keep their
+sides out. As for the Ball of Fire, the false Wizard had hung that also
+from the ceiling. It was really a ball of cotton, but when oil was
+poured upon it the ball burned fiercely.
+
+“Really,” said the Scarecrow, “you ought to be ashamed of yourself for
+being such a humbug.”
+
+“I am—I certainly am,” answered the little man sorrowfully; “but it was
+the only thing I could do. Sit down, please, there are plenty of
+chairs; and I will tell you my story.”
+
+So they sat down and listened while he told the following tale.
+
+“I was born in Omaha—”
+
+“Why, that isn’t very far from Kansas!” cried Dorothy.
+
+“No, but it’s farther from here,” he said, shaking his head at her
+sadly. “When I grew up I became a ventriloquist, and at that I was very
+well trained by a great master. I can imitate any kind of a bird or
+beast.” Here he mewed so like a kitten that Toto pricked up his ears
+and looked everywhere to see where she was. “After a time,” continued
+Oz, “I tired of that, and became a balloonist.”
+
+“What is that?” asked Dorothy.
+
+“A man who goes up in a balloon on circus day, so as to draw a crowd of
+people together and get them to pay to see the circus,” he explained.
+
+“Oh,” she said, “I know.”
+
+“Well, one day I went up in a balloon and the ropes got twisted, so
+that I couldn’t come down again. It went way up above the clouds, so
+far that a current of air struck it and carried it many, many miles
+away. For a day and a night I traveled through the air, and on the
+morning of the second day I awoke and found the balloon floating over a
+strange and beautiful country.
+
+“It came down gradually, and I was not hurt a bit. But I found myself
+in the midst of a strange people, who, seeing me come from the clouds,
+thought I was a great Wizard. Of course I let them think so, because
+they were afraid of me, and promised to do anything I wished them to.
+
+“Just to amuse myself, and keep the good people busy, I ordered them to
+build this City, and my Palace; and they did it all willingly and well.
+Then I thought, as the country was so green and beautiful, I would call
+it the Emerald City; and to make the name fit better I put green
+spectacles on all the people, so that everything they saw was green.”
+
+“But isn’t everything here green?” asked Dorothy.
+
+“No more than in any other city,” replied Oz; “but when you wear green
+spectacles, why of course everything you see looks green to you. The
+Emerald City was built a great many years ago, for I was a young man
+when the balloon brought me here, and I am a very old man now. But my
+people have worn green glasses on their eyes so long that most of them
+think it really is an Emerald City, and it certainly is a beautiful
+place, abounding in jewels and precious metals, and every good thing
+that is needed to make one happy. I have been good to the people, and
+they like me; but ever since this Palace was built, I have shut myself
+up and would not see any of them.
+
+“One of my greatest fears was the Witches, for while I had no magical
+powers at all I soon found out that the Witches were really able to do
+wonderful things. There were four of them in this country, and they
+ruled the people who live in the North and South and East and West.
+Fortunately, the Witches of the North and South were good, and I knew
+they would do me no harm; but the Witches of the East and West were
+terribly wicked, and had they not thought I was more powerful than they
+themselves, they would surely have destroyed me. As it was, I lived in
+deadly fear of them for many years; so you can imagine how pleased I
+was when I heard your house had fallen on the Wicked Witch of the East.
+When you came to me, I was willing to promise anything if you would
+only do away with the other Witch; but, now that you have melted her, I
+am ashamed to say that I cannot keep my promises.”
+
+“I think you are a very bad man,” said Dorothy.
+
+“Oh, no, my dear; I’m really a very good man, but I’m a very bad
+Wizard, I must admit.”
+
+“Can’t you give me brains?” asked the Scarecrow.
+
+“You don’t need them. You are learning something every day. A baby has
+brains, but it doesn’t know much. Experience is the only thing that
+brings knowledge, and the longer you are on earth the more experience
+you are sure to get.”
+
+“That may all be true,” said the Scarecrow, “but I shall be very
+unhappy unless you give me brains.”
+
+The false Wizard looked at him carefully.
+
+“Well,” he said with a sigh, “I’m not much of a magician, as I said;
+but if you will come to me tomorrow morning, I will stuff your head
+with brains. I cannot tell you how to use them, however; you must find
+that out for yourself.”
+
+“Oh, thank you—thank you!” cried the Scarecrow. “I’ll find a way to use
+them, never fear!”
+
+“But how about my courage?” asked the Lion anxiously.
+
+“You have plenty of courage, I am sure,” answered Oz. “All you need is
+confidence in yourself. There is no living thing that is not afraid
+when it faces danger. The True courage is in facing danger when you are
+afraid, and that kind of courage you have in plenty.”
+
+“Perhaps I have, but I’m scared just the same,” said the Lion. “I shall
+really be very unhappy unless you give me the sort of courage that
+makes one forget he is afraid.”
+
+“Very well, I will give you that sort of courage tomorrow,” replied Oz.
+
+“How about my heart?” asked the Tin Woodman.
+
+“Why, as for that,” answered Oz, “I think you are wrong to want a
+heart. It makes most people unhappy. If you only knew it, you are in
+luck not to have a heart.”
+
+“That must be a matter of opinion,” said the Tin Woodman. “For my part,
+I will bear all the unhappiness without a murmur, if you will give me
+the heart.”
+
+“Very well,” answered Oz meekly. “Come to me tomorrow and you shall
+have a heart. I have played Wizard for so many years that I may as well
+continue the part a little longer.”
+
+“And now,” said Dorothy, “how am I to get back to Kansas?”
+
+“We shall have to think about that,” replied the little man. “Give me
+two or three days to consider the matter and I’ll try to find a way to
+carry you over the desert. In the meantime you shall all be treated as
+my guests, and while you live in the Palace my people will wait upon
+you and obey your slightest wish. There is only one thing I ask in
+return for my help—such as it is. You must keep my secret and tell no
+one I am a humbug.”
+
+They agreed to say nothing of what they had learned, and went back to
+their rooms in high spirits. Even Dorothy had hope that “The Great and
+Terrible Humbug,” as she called him, would find a way to send her back
+to Kansas, and if he did she was willing to forgive him everything.
+
+
+
+
+Chapter XVI
+The Magic Art of the Great Humbug
+
+
+Next morning the Scarecrow said to his friends:
+
+“Congratulate me. I am going to Oz to get my brains at last. When I
+return I shall be as other men are.”
+
+“I have always liked you as you were,” said Dorothy simply.
+
+“It is kind of you to like a Scarecrow,” he replied. “But surely you
+will think more of me when you hear the splendid thoughts my new brain
+is going to turn out.” Then he said good-bye to them all in a cheerful
+voice and went to the Throne Room, where he rapped upon the door.
+
+“Come in,” said Oz.
+
+The Scarecrow went in and found the little man sitting down by the
+window, engaged in deep thought.
+
+“I have come for my brains,” remarked the Scarecrow, a little uneasily.
+
+“Oh, yes; sit down in that chair, please,” replied Oz. “You must excuse
+me for taking your head off, but I shall have to do it in order to put
+your brains in their proper place.”
+
+“That’s all right,” said the Scarecrow. “You are quite welcome to take
+my head off, as long as it will be a better one when you put it on
+again.”
+
+So the Wizard unfastened his head and emptied out the straw. Then he
+entered the back room and took up a measure of bran, which he mixed
+with a great many pins and needles. Having shaken them together
+thoroughly, he filled the top of the Scarecrow’s head with the mixture
+and stuffed the rest of the space with straw, to hold it in place.
+
+When he had fastened the Scarecrow’s head on his body again he said to
+him, “Hereafter you will be a great man, for I have given you a lot of
+bran-new brains.”
+
+The Scarecrow was both pleased and proud at the fulfillment of his
+greatest wish, and having thanked Oz warmly he went back to his
+friends.
+
+Dorothy looked at him curiously. His head was quite bulged out at the
+top with brains.
+
+“How do you feel?” she asked.
+
+“I feel wise indeed,” he answered earnestly. “When I get used to my
+brains I shall know everything.”
+
+“Why are those needles and pins sticking out of your head?” asked the
+Tin Woodman.
+
+“That is proof that he is sharp,” remarked the Lion.
+
+“Well, I must go to Oz and get my heart,” said the Woodman. So he
+walked to the Throne Room and knocked at the door.
+
+“Come in,” called Oz, and the Woodman entered and said, “I have come
+for my heart.”
+
+“Very well,” answered the little man. “But I shall have to cut a hole
+in your breast, so I can put your heart in the right place. I hope it
+won’t hurt you.”
+
+“Oh, no,” answered the Woodman. “I shall not feel it at all.”
+
+So Oz brought a pair of tinsmith’s shears and cut a small, square hole
+in the left side of the Tin Woodman’s breast. Then, going to a chest of
+drawers, he took out a pretty heart, made entirely of silk and stuffed
+with sawdust.
+
+“Isn’t it a beauty?” he asked.
+
+“It is, indeed!” replied the Woodman, who was greatly pleased. “But is
+it a kind heart?”
+
+“Oh, very!” answered Oz. He put the heart in the Woodman’s breast and
+then replaced the square of tin, soldering it neatly together where it
+had been cut.
+
+“There,” said he; “now you have a heart that any man might be proud of.
+I’m sorry I had to put a patch on your breast, but it really couldn’t
+be helped.”
+
+“Never mind the patch,” exclaimed the happy Woodman. “I am very
+grateful to you, and shall never forget your kindness.”
+
+“Don’t speak of it,” replied Oz.
+
+Then the Tin Woodman went back to his friends, who wished him every joy
+on account of his good fortune.
+
+The Lion now walked to the Throne Room and knocked at the door.
+
+“Come in,” said Oz.
+
+“I have come for my courage,” announced the Lion, entering the room.
+
+“Very well,” answered the little man; “I will get it for you.”
+
+He went to a cupboard and reaching up to a high shelf took down a
+square green bottle, the contents of which he poured into a green-gold
+dish, beautifully carved. Placing this before the Cowardly Lion, who
+sniffed at it as if he did not like it, the Wizard said:
+
+“Drink.”
+
+“What is it?” asked the Lion.
+
+“Well,” answered Oz, “if it were inside of you, it would be courage.
+You know, of course, that courage is always inside one; so that this
+really cannot be called courage until you have swallowed it. Therefore
+I advise you to drink it as soon as possible.”
+
+The Lion hesitated no longer, but drank till the dish was empty.
+
+“How do you feel now?” asked Oz.
+
+“Full of courage,” replied the Lion, who went joyfully back to his
+friends to tell them of his good fortune.
+
+Oz, left to himself, smiled to think of his success in giving the
+Scarecrow and the Tin Woodman and the Lion exactly what they thought
+they wanted. “How can I help being a humbug,” he said, “when all these
+people make me do things that everybody knows can’t be done? It was
+easy to make the Scarecrow and the Lion and the Woodman happy, because
+they imagined I could do anything. But it will take more than
+imagination to carry Dorothy back to Kansas, and I’m sure I don’t know
+how it can be done.”
+
+
+
+
+Chapter XVII
+How the Balloon Was Launched
+
+
+For three days Dorothy heard nothing from Oz. These were sad days for
+the little girl, although her friends were all quite happy and
+contented. The Scarecrow told them there were wonderful thoughts in his
+head; but he would not say what they were because he knew no one could
+understand them but himself. When the Tin Woodman walked about he felt
+his heart rattling around in his breast; and he told Dorothy he had
+discovered it to be a kinder and more tender heart than the one he had
+owned when he was made of flesh. The Lion declared he was afraid of
+nothing on earth, and would gladly face an army or a dozen of the
+fierce Kalidahs.
+
+Thus each of the little party was satisfied except Dorothy, who longed
+more than ever to get back to Kansas.
+
+On the fourth day, to her great joy, Oz sent for her, and when she
+entered the Throne Room he greeted her pleasantly:
+
+“Sit down, my dear; I think I have found the way to get you out of this
+country.”
+
+“And back to Kansas?” she asked eagerly.
+
+“Well, I’m not sure about Kansas,” said Oz, “for I haven’t the faintest
+notion which way it lies. But the first thing to do is to cross the
+desert, and then it should be easy to find your way home.”
+
+“How can I cross the desert?” she inquired.
+
+“Well, I’ll tell you what I think,” said the little man. “You see, when
+I came to this country it was in a balloon. You also came through the
+air, being carried by a cyclone. So I believe the best way to get
+across the desert will be through the air. Now, it is quite beyond my
+powers to make a cyclone; but I’ve been thinking the matter over, and I
+believe I can make a balloon.”
+
+“How?” asked Dorothy.
+
+“A balloon,” said Oz, “is made of silk, which is coated with glue to
+keep the gas in it. I have plenty of silk in the Palace, so it will be
+no trouble to make the balloon. But in all this country there is no gas
+to fill the balloon with, to make it float.”
+
+“If it won’t float,” remarked Dorothy, “it will be of no use to us.”
+
+“True,” answered Oz. “But there is another way to make it float, which
+is to fill it with hot air. Hot air isn’t as good as gas, for if the
+air should get cold the balloon would come down in the desert, and we
+should be lost.”
+
+“We!” exclaimed the girl. “Are you going with me?”
+
+“Yes, of course,” replied Oz. “I am tired of being such a humbug. If I
+should go out of this Palace my people would soon discover I am not a
+Wizard, and then they would be vexed with me for having deceived them.
+So I have to stay shut up in these rooms all day, and it gets tiresome.
+I’d much rather go back to Kansas with you and be in a circus again.”
+
+“I shall be glad to have your company,” said Dorothy.
+
+“Thank you,” he answered. “Now, if you will help me sew the silk
+together, we will begin to work on our balloon.”
+
+So Dorothy took a needle and thread, and as fast as Oz cut the strips
+of silk into proper shape the girl sewed them neatly together. First
+there was a strip of light green silk, then a strip of dark green and
+then a strip of emerald green; for Oz had a fancy to make the balloon
+in different shades of the color about them. It took three days to sew
+all the strips together, but when it was finished they had a big bag of
+green silk more than twenty feet long.
+
+Then Oz painted it on the inside with a coat of thin glue, to make it
+airtight, after which he announced that the balloon was ready.
+
+“But we must have a basket to ride in,” he said. So he sent the soldier
+with the green whiskers for a big clothes basket, which he fastened
+with many ropes to the bottom of the balloon.
+
+When it was all ready, Oz sent word to his people that he was going to
+make a visit to a great brother Wizard who lived in the clouds. The
+news spread rapidly throughout the city and everyone came to see the
+wonderful sight.
+
+Oz ordered the balloon carried out in front of the Palace, and the
+people gazed upon it with much curiosity. The Tin Woodman had chopped a
+big pile of wood, and now he made a fire of it, and Oz held the bottom
+of the balloon over the fire so that the hot air that arose from it
+would be caught in the silken bag. Gradually the balloon swelled out
+and rose into the air, until finally the basket just touched the
+ground.
+
+Then Oz got into the basket and said to all the people in a loud voice:
+
+“I am now going away to make a visit. While I am gone the Scarecrow
+will rule over you. I command you to obey him as you would me.”
+
+The balloon was by this time tugging hard at the rope that held it to
+the ground, for the air within it was hot, and this made it so much
+lighter in weight than the air without that it pulled hard to rise into
+the sky.
+
+“Come, Dorothy!” cried the Wizard. “Hurry up, or the balloon will fly
+away.”
+
+“I can’t find Toto anywhere,” replied Dorothy, who did not wish to
+leave her little dog behind. Toto had run into the crowd to bark at a
+kitten, and Dorothy at last found him. She picked him up and ran
+towards the balloon.
+
+She was within a few steps of it, and Oz was holding out his hands to
+help her into the basket, when, crack! went the ropes, and the balloon
+rose into the air without her.
+
+“Come back!” she screamed. “I want to go, too!”
+
+“I can’t come back, my dear,” called Oz from the basket. “Good-bye!”
+
+“Good-bye!” shouted everyone, and all eyes were turned upward to where
+the Wizard was riding in the basket, rising every moment farther and
+farther into the sky.
+
+And that was the last any of them ever saw of Oz, the Wonderful Wizard,
+though he may have reached Omaha safely, and be there now, for all we
+know. But the people remembered him lovingly, and said to one another:
+
+“Oz was always our friend. When he was here he built for us this
+beautiful Emerald City, and now he is gone he has left the Wise
+Scarecrow to rule over us.”
+
+Still, for many days they grieved over the loss of the Wonderful
+Wizard, and would not be comforted.
+
+
+
+
+Chapter XVIII
+Away to the South
+
+
+Dorothy wept bitterly at the passing of her hope to get home to Kansas
+again; but when she thought it all over she was glad she had not gone
+up in a balloon. And she also felt sorry at losing Oz, and so did her
+companions.
+
+The Tin Woodman came to her and said:
+
+“Truly I should be ungrateful if I failed to mourn for the man who gave
+me my lovely heart. I should like to cry a little because Oz is gone,
+if you will kindly wipe away my tears, so that I shall not rust.”
+
+“With pleasure,” she answered, and brought a towel at once. Then the
+Tin Woodman wept for several minutes, and she watched the tears
+carefully and wiped them away with the towel. When he had finished, he
+thanked her kindly and oiled himself thoroughly with his jeweled
+oil-can, to guard against mishap.
+
+The Scarecrow was now the ruler of the Emerald City, and although he
+was not a Wizard the people were proud of him. “For,” they said, “there
+is not another city in all the world that is ruled by a stuffed man.”
+And, so far as they knew, they were quite right.
+
+The morning after the balloon had gone up with Oz, the four travelers
+met in the Throne Room and talked matters over. The Scarecrow sat in
+the big throne and the others stood respectfully before him.
+
+“We are not so unlucky,” said the new ruler, “for this Palace and the
+Emerald City belong to us, and we can do just as we please. When I
+remember that a short time ago I was up on a pole in a farmer’s
+cornfield, and that now I am the ruler of this beautiful City, I am
+quite satisfied with my lot.”
+
+“I also,” said the Tin Woodman, “am well-pleased with my new heart;
+and, really, that was the only thing I wished in all the world.”
+
+“For my part, I am content in knowing I am as brave as any beast that
+ever lived, if not braver,” said the Lion modestly.
+
+“If Dorothy would only be contented to live in the Emerald City,”
+continued the Scarecrow, “we might all be happy together.”
+
+“But I don’t want to live here,” cried Dorothy. “I want to go to
+Kansas, and live with Aunt Em and Uncle Henry.”
+
+“Well, then, what can be done?” inquired the Woodman.
+
+The Scarecrow decided to think, and he thought so hard that the pins
+and needles began to stick out of his brains. Finally he said:
+
+“Why not call the Winged Monkeys, and ask them to carry you over the
+desert?”
+
+“I never thought of that!” said Dorothy joyfully. “It’s just the thing.
+I’ll go at once for the Golden Cap.”
+
+When she brought it into the Throne Room she spoke the magic words, and
+soon the band of Winged Monkeys flew in through the open window and
+stood beside her.
+
+“This is the second time you have called us,” said the Monkey King,
+bowing before the little girl. “What do you wish?”
+
+“I want you to fly with me to Kansas,” said Dorothy.
+
+But the Monkey King shook his head.
+
+“That cannot be done,” he said. “We belong to this country alone, and
+cannot leave it. There has never been a Winged Monkey in Kansas yet,
+and I suppose there never will be, for they don’t belong there. We
+shall be glad to serve you in any way in our power, but we cannot cross
+the desert. Good-bye.”
+
+And with another bow, the Monkey King spread his wings and flew away
+through the window, followed by all his band.
+
+Dorothy was ready to cry with disappointment. “I have wasted the charm
+of the Golden Cap to no purpose,” she said, “for the Winged Monkeys
+cannot help me.”
+
+“It is certainly too bad!” said the tender-hearted Woodman.
+
+The Scarecrow was thinking again, and his head bulged out so horribly
+that Dorothy feared it would burst.
+
+“Let us call in the soldier with the green whiskers,” he said, “and ask
+his advice.”
+
+So the soldier was summoned and entered the Throne Room timidly, for
+while Oz was alive he never was allowed to come farther than the door.
+
+“This little girl,” said the Scarecrow to the soldier, “wishes to cross
+the desert. How can she do so?”
+
+“I cannot tell,” answered the soldier, “for nobody has ever crossed the
+desert, unless it is Oz himself.”
+
+“Is there no one who can help me?” asked Dorothy earnestly.
+
+“Glinda might,” he suggested.
+
+“Who is Glinda?” inquired the Scarecrow.
+
+“The Witch of the South. She is the most powerful of all the Witches,
+and rules over the Quadlings. Besides, her castle stands on the edge of
+the desert, so she may know a way to cross it.”
+
+“Glinda is a Good Witch, isn’t she?” asked the child.
+
+“The Quadlings think she is good,” said the soldier, “and she is kind
+to everyone. I have heard that Glinda is a beautiful woman, who knows
+how to keep young in spite of the many years she has lived.”
+
+“How can I get to her castle?” asked Dorothy.
+
+“The road is straight to the South,” he answered, “but it is said to be
+full of dangers to travelers. There are wild beasts in the woods, and a
+race of queer men who do not like strangers to cross their country. For
+this reason none of the Quadlings ever come to the Emerald City.”
+
+The soldier then left them and the Scarecrow said:
+
+“It seems, in spite of dangers, that the best thing Dorothy can do is
+to travel to the Land of the South and ask Glinda to help her. For, of
+course, if Dorothy stays here she will never get back to Kansas.”
+
+“You must have been thinking again,” remarked the Tin Woodman.
+
+“I have,” said the Scarecrow.
+
+“I shall go with Dorothy,” declared the Lion, “for I am tired of your
+city and long for the woods and the country again. I am really a wild
+beast, you know. Besides, Dorothy will need someone to protect her.”
+
+“That is true,” agreed the Woodman. “My axe may be of service to her;
+so I also will go with her to the Land of the South.”
+
+“When shall we start?” asked the Scarecrow.
+
+“Are you going?” they asked, in surprise.
+
+“Certainly. If it wasn’t for Dorothy I should never have had brains.
+She lifted me from the pole in the cornfield and brought me to the
+Emerald City. So my good luck is all due to her, and I shall never
+leave her until she starts back to Kansas for good and all.”
+
+“Thank you,” said Dorothy gratefully. “You are all very kind to me. But
+I should like to start as soon as possible.”
+
+“We shall go tomorrow morning,” returned the Scarecrow. “So now let us
+all get ready, for it will be a long journey.”
+
+
+
+
+Chapter XIX
+Attacked by the Fighting Trees
+
+
+The next morning Dorothy kissed the pretty green girl good-bye, and
+they all shook hands with the soldier with the green whiskers, who had
+walked with them as far as the gate. When the Guardian of the Gate saw
+them again he wondered greatly that they could leave the beautiful City
+to get into new trouble. But he at once unlocked their spectacles,
+which he put back into the green box, and gave them many good wishes to
+carry with them.
+
+“You are now our ruler,” he said to the Scarecrow; “so you must come
+back to us as soon as possible.”
+
+“I certainly shall if I am able,” the Scarecrow replied; “but I must
+help Dorothy to get home, first.”
+
+As Dorothy bade the good-natured Guardian a last farewell she said:
+
+“I have been very kindly treated in your lovely City, and everyone has
+been good to me. I cannot tell you how grateful I am.”
+
+“Don’t try, my dear,” he answered. “We should like to keep you with us,
+but if it is your wish to return to Kansas, I hope you will find a
+way.” He then opened the gate of the outer wall, and they walked forth
+and started upon their journey.
+
+The sun shone brightly as our friends turned their faces toward the
+Land of the South. They were all in the best of spirits, and laughed
+and chatted together. Dorothy was once more filled with the hope of
+getting home, and the Scarecrow and the Tin Woodman were glad to be of
+use to her. As for the Lion, he sniffed the fresh air with delight and
+whisked his tail from side to side in pure joy at being in the country
+again, while Toto ran around them and chased the moths and butterflies,
+barking merrily all the time.
+
+“City life does not agree with me at all,” remarked the Lion, as they
+walked along at a brisk pace. “I have lost much flesh since I lived
+there, and now I am anxious for a chance to show the other beasts how
+courageous I have grown.”
+
+They now turned and took a last look at the Emerald City. All they
+could see was a mass of towers and steeples behind the green walls, and
+high up above everything the spires and dome of the Palace of Oz.
+
+“Oz was not such a bad Wizard, after all,” said the Tin Woodman, as he
+felt his heart rattling around in his breast.
+
+“He knew how to give me brains, and very good brains, too,” said the
+Scarecrow.
+
+“If Oz had taken a dose of the same courage he gave me,” added the
+Lion, “he would have been a brave man.”
+
+Dorothy said nothing. Oz had not kept the promise he made her, but he
+had done his best, so she forgave him. As he said, he was a good man,
+even if he was a bad Wizard.
+
+The first day’s journey was through the green fields and bright flowers
+that stretched about the Emerald City on every side. They slept that
+night on the grass, with nothing but the stars over them; and they
+rested very well indeed.
+
+In the morning they traveled on until they came to a thick wood. There
+was no way of going around it, for it seemed to extend to the right and
+left as far as they could see; and, besides, they did not dare change
+the direction of their journey for fear of getting lost. So they looked
+for the place where it would be easiest to get into the forest.
+
+The Scarecrow, who was in the lead, finally discovered a big tree with
+such wide-spreading branches that there was room for the party to pass
+underneath. So he walked forward to the tree, but just as he came under
+the first branches they bent down and twined around him, and the next
+minute he was raised from the ground and flung headlong among his
+fellow travelers.
+
+This did not hurt the Scarecrow, but it surprised him, and he looked
+rather dizzy when Dorothy picked him up.
+
+“Here is another space between the trees,” called the Lion.
+
+“Let me try it first,” said the Scarecrow, “for it doesn’t hurt me to
+get thrown about.” He walked up to another tree, as he spoke, but its
+branches immediately seized him and tossed him back again.
+
+“This is strange,” exclaimed Dorothy. “What shall we do?”
+
+“The trees seem to have made up their minds to fight us, and stop our
+journey,” remarked the Lion.
+
+“I believe I will try it myself,” said the Woodman, and shouldering his
+axe, he marched up to the first tree that had handled the Scarecrow so
+roughly. When a big branch bent down to seize him the Woodman chopped
+at it so fiercely that he cut it in two. At once the tree began shaking
+all its branches as if in pain, and the Tin Woodman passed safely under
+it.
+
+“Come on!” he shouted to the others. “Be quick!” They all ran forward
+and passed under the tree without injury, except Toto, who was caught
+by a small branch and shaken until he howled. But the Woodman promptly
+chopped off the branch and set the little dog free.
+
+The other trees of the forest did nothing to keep them back, so they
+made up their minds that only the first row of trees could bend down
+their branches, and that probably these were the policemen of the
+forest, and given this wonderful power in order to keep strangers out
+of it.
+
+The four travelers walked with ease through the trees until they came
+to the farther edge of the wood. Then, to their surprise, they found
+before them a high wall which seemed to be made of white china. It was
+smooth, like the surface of a dish, and higher than their heads.
+
+“What shall we do now?” asked Dorothy.
+
+“I will make a ladder,” said the Tin Woodman, “for we certainly must
+climb over the wall.”
+
+
+
+
+Chapter XX
+The Dainty China Country
+
+
+While the Woodman was making a ladder from wood which he found in the
+forest Dorothy lay down and slept, for she was tired by the long walk.
+The Lion also curled himself up to sleep and Toto lay beside him.
+
+The Scarecrow watched the Woodman while he worked, and said to him:
+
+“I cannot think why this wall is here, nor what it is made of.”
+
+“Rest your brains and do not worry about the wall,” replied the
+Woodman. “When we have climbed over it, we shall know what is on the
+other side.”
+
+After a time the ladder was finished. It looked clumsy, but the Tin
+Woodman was sure it was strong and would answer their purpose. The
+Scarecrow waked Dorothy and the Lion and Toto, and told them that the
+ladder was ready. The Scarecrow climbed up the ladder first, but he was
+so awkward that Dorothy had to follow close behind and keep him from
+falling off. When he got his head over the top of the wall the
+Scarecrow said, “Oh, my!”
+
+“Go on,” exclaimed Dorothy.
+
+So the Scarecrow climbed farther up and sat down on the top of the
+wall, and Dorothy put her head over and cried, “Oh, my!” just as the
+Scarecrow had done.
+
+Then Toto came up, and immediately began to bark, but Dorothy made him
+be still.
+
+The Lion climbed the ladder next, and the Tin Woodman came last; but
+both of them cried, “Oh, my!” as soon as they looked over the wall.
+When they were all sitting in a row on the top of the wall, they looked
+down and saw a strange sight.
+
+Before them was a great stretch of country having a floor as smooth and
+shining and white as the bottom of a big platter. Scattered around were
+many houses made entirely of china and painted in the brightest colors.
+These houses were quite small, the biggest of them reaching only as
+high as Dorothy’s waist. There were also pretty little barns, with
+china fences around them; and many cows and sheep and horses and pigs
+and chickens, all made of china, were standing about in groups.
+
+But the strangest of all were the people who lived in this queer
+country. There were milkmaids and shepherdesses, with brightly colored
+bodices and golden spots all over their gowns; and princesses with most
+gorgeous frocks of silver and gold and purple; and shepherds dressed in
+knee breeches with pink and yellow and blue stripes down them, and
+golden buckles on their shoes; and princes with jeweled crowns upon
+their heads, wearing ermine robes and satin doublets; and funny clowns
+in ruffled gowns, with round red spots upon their cheeks and tall,
+pointed caps. And, strangest of all, these people were all made of
+china, even to their clothes, and were so small that the tallest of
+them was no higher than Dorothy’s knee.
+
+No one did so much as look at the travelers at first, except one little
+purple china dog with an extra-large head, which came to the wall and
+barked at them in a tiny voice, afterwards running away again.
+
+“How shall we get down?” asked Dorothy.
+
+They found the ladder so heavy they could not pull it up, so the
+Scarecrow fell off the wall and the others jumped down upon him so that
+the hard floor would not hurt their feet. Of course they took pains not
+to light on his head and get the pins in their feet. When all were
+safely down they picked up the Scarecrow, whose body was quite
+flattened out, and patted his straw into shape again.
+
+“We must cross this strange place in order to get to the other side,”
+said Dorothy, “for it would be unwise for us to go any other way except
+due South.”
+
+They began walking through the country of the china people, and the
+first thing they came to was a china milkmaid milking a china cow. As
+they drew near, the cow suddenly gave a kick and kicked over the stool,
+the pail, and even the milkmaid herself, and all fell on the china
+ground with a great clatter.
+
+Dorothy was shocked to see that the cow had broken her leg off, and
+that the pail was lying in several small pieces, while the poor
+milkmaid had a nick in her left elbow.
+
+“There!” cried the milkmaid angrily. “See what you have done! My cow
+has broken her leg, and I must take her to the mender’s shop and have
+it glued on again. What do you mean by coming here and frightening my
+cow?”
+
+“I’m very sorry,” returned Dorothy. “Please forgive us.”
+
+But the pretty milkmaid was much too vexed to make any answer. She
+picked up the leg sulkily and led her cow away, the poor animal limping
+on three legs. As she left them the milkmaid cast many reproachful
+glances over her shoulder at the clumsy strangers, holding her nicked
+elbow close to her side.
+
+Dorothy was quite grieved at this mishap.
+
+“We must be very careful here,” said the kind-hearted Woodman, “or we
+may hurt these pretty little people so they will never get over it.”
+
+A little farther on Dorothy met a most beautifully dressed young
+Princess, who stopped short as she saw the strangers and started to run
+away.
+
+Dorothy wanted to see more of the Princess, so she ran after her. But
+the china girl cried out:
+
+“Don’t chase me! Don’t chase me!”
+
+She had such a frightened little voice that Dorothy stopped and said,
+“Why not?”
+
+“Because,” answered the Princess, also stopping, a safe distance away,
+“if I run I may fall down and break myself.”
+
+“But could you not be mended?” asked the girl.
+
+“Oh, yes; but one is never so pretty after being mended, you know,”
+replied the Princess.
+
+“I suppose not,” said Dorothy.
+
+“Now there is Mr. Joker, one of our clowns,” continued the china lady,
+“who is always trying to stand upon his head. He has broken himself so
+often that he is mended in a hundred places, and doesn’t look at all
+pretty. Here he comes now, so you can see for yourself.”
+
+Indeed, a jolly little clown came walking toward them, and Dorothy
+could see that in spite of his pretty clothes of red and yellow and
+green he was completely covered with cracks, running every which way
+and showing plainly that he had been mended in many places.
+
+The Clown put his hands in his pockets, and after puffing out his
+cheeks and nodding his head at them saucily, he said:
+
+    “My lady fair,
+   Why do you stare
+At poor old Mr. Joker?
+    You’re quite as stiff
+    And prim as if
+You’d eaten up a poker!”
+
+
+“Be quiet, sir!” said the Princess. “Can’t you see these are strangers,
+and should be treated with respect?”
+
+“Well, that’s respect, I expect,” declared the Clown, and immediately
+stood upon his head.
+
+“Don’t mind Mr. Joker,” said the Princess to Dorothy. “He is
+considerably cracked in his head, and that makes him foolish.”
+
+“Oh, I don’t mind him a bit,” said Dorothy. “But you are so beautiful,”
+she continued, “that I am sure I could love you dearly. Won’t you let
+me carry you back to Kansas, and stand you on Aunt Em’s mantel? I could
+carry you in my basket.”
+
+“That would make me very unhappy,” answered the china Princess. “You
+see, here in our country we live contentedly, and can talk and move
+around as we please. But whenever any of us are taken away our joints
+at once stiffen, and we can only stand straight and look pretty. Of
+course that is all that is expected of us when we are on mantels and
+cabinets and drawing-room tables, but our lives are much pleasanter
+here in our own country.”
+
+“I would not make you unhappy for all the world!” exclaimed Dorothy.
+“So I’ll just say good-bye.”
+
+“Good-bye,” replied the Princess.
+
+They walked carefully through the china country. The little animals and
+all the people scampered out of their way, fearing the strangers would
+break them, and after an hour or so the travelers reached the other
+side of the country and came to another china wall.
+
+It was not so high as the first, however, and by standing upon the
+Lion’s back they all managed to scramble to the top. Then the Lion
+gathered his legs under him and jumped on the wall; but just as he
+jumped, he upset a china church with his tail and smashed it all to
+pieces.
+
+“That was too bad,” said Dorothy, “but really I think we were lucky in
+not doing these little people more harm than breaking a cow’s leg and a
+church. They are all so brittle!”
+
+“They are, indeed,” said the Scarecrow, “and I am thankful I am made of
+straw and cannot be easily damaged. There are worse things in the world
+than being a Scarecrow.”
+
+
+
+
+Chapter XXI
+The Lion Becomes the King of Beasts
+
+
+After climbing down from the china wall the travelers found themselves
+in a disagreeable country, full of bogs and marshes and covered with
+tall, rank grass. It was difficult to walk without falling into muddy
+holes, for the grass was so thick that it hid them from sight. However,
+by carefully picking their way, they got safely along until they
+reached solid ground. But here the country seemed wilder than ever, and
+after a long and tiresome walk through the underbrush they entered
+another forest, where the trees were bigger and older than any they had
+ever seen.
+
+“This forest is perfectly delightful,” declared the Lion, looking
+around him with joy. “Never have I seen a more beautiful place.”
+
+“It seems gloomy,” said the Scarecrow.
+
+“Not a bit of it,” answered the Lion. “I should like to live here all
+my life. See how soft the dried leaves are under your feet and how rich
+and green the moss is that clings to these old trees. Surely no wild
+beast could wish a pleasanter home.”
+
+“Perhaps there are wild beasts in the forest now,” said Dorothy.
+
+“I suppose there are,” returned the Lion, “but I do not see any of them
+about.”
+
+They walked through the forest until it became too dark to go any
+farther. Dorothy and Toto and the Lion lay down to sleep, while the
+Woodman and the Scarecrow kept watch over them as usual.
+
+When morning came, they started again. Before they had gone far they
+heard a low rumble, as of the growling of many wild animals. Toto
+whimpered a little, but none of the others was frightened, and they
+kept along the well-trodden path until they came to an opening in the
+wood, in which were gathered hundreds of beasts of every variety. There
+were tigers and elephants and bears and wolves and foxes and all the
+others in the natural history, and for a moment Dorothy was afraid. But
+the Lion explained that the animals were holding a meeting, and he
+judged by their snarling and growling that they were in great trouble.
+
+As he spoke several of the beasts caught sight of him, and at once the
+great assemblage hushed as if by magic. The biggest of the tigers came
+up to the Lion and bowed, saying:
+
+“Welcome, O King of Beasts! You have come in good time to fight our
+enemy and bring peace to all the animals of the forest once more.”
+
+“What is your trouble?” asked the Lion quietly.
+
+“We are all threatened,” answered the tiger, “by a fierce enemy which
+has lately come into this forest. It is a most tremendous monster, like
+a great spider, with a body as big as an elephant and legs as long as a
+tree trunk. It has eight of these long legs, and as the monster crawls
+through the forest he seizes an animal with a leg and drags it to his
+mouth, where he eats it as a spider does a fly. Not one of us is safe
+while this fierce creature is alive, and we had called a meeting to
+decide how to take care of ourselves when you came among us.”
+
+The Lion thought for a moment.
+
+“Are there any other lions in this forest?” he asked.
+
+“No; there were some, but the monster has eaten them all. And, besides,
+they were none of them nearly so large and brave as you.”
+
+“If I put an end to your enemy, will you bow down to me and obey me as
+King of the Forest?” inquired the Lion.
+
+“We will do that gladly,” returned the tiger; and all the other beasts
+roared with a mighty roar: “We will!”
+
+“Where is this great spider of yours now?” asked the Lion.
+
+“Yonder, among the oak trees,” said the tiger, pointing with his
+forefoot.
+
+“Take good care of these friends of mine,” said the Lion, “and I will
+go at once to fight the monster.”
+
+He bade his comrades good-bye and marched proudly away to do battle
+with the enemy.
+
+The great spider was lying asleep when the Lion found him, and it
+looked so ugly that its foe turned up his nose in disgust. Its legs
+were quite as long as the tiger had said, and its body covered with
+coarse black hair. It had a great mouth, with a row of sharp teeth a
+foot long; but its head was joined to the pudgy body by a neck as
+slender as a wasp’s waist. This gave the Lion a hint of the best way to
+attack the creature, and as he knew it was easier to fight it asleep
+than awake, he gave a great spring and landed directly upon the
+monster’s back. Then, with one blow of his heavy paw, all armed with
+sharp claws, he knocked the spider’s head from its body. Jumping down,
+he watched it until the long legs stopped wiggling, when he knew it was
+quite dead.
+
+The Lion went back to the opening where the beasts of the forest were
+waiting for him and said proudly:
+
+“You need fear your enemy no longer.”
+
+Then the beasts bowed down to the Lion as their King, and he promised
+to come back and rule over them as soon as Dorothy was safely on her
+way to Kansas.
+
+
+
+
+Chapter XXII
+The Country of the Quadlings
+
+
+The four travelers passed through the rest of the forest in safety, and
+when they came out from its gloom saw before them a steep hill, covered
+from top to bottom with great pieces of rock.
+
+“That will be a hard climb,” said the Scarecrow, “but we must get over
+the hill, nevertheless.”
+
+So he led the way and the others followed. They had nearly reached the
+first rock when they heard a rough voice cry out, “Keep back!”
+
+“Who are you?” asked the Scarecrow.
+
+Then a head showed itself over the rock and the same voice said, “This
+hill belongs to us, and we don’t allow anyone to cross it.”
+
+“But we must cross it,” said the Scarecrow. “We’re going to the country
+of the Quadlings.”
+
+“But you shall not!” replied the voice, and there stepped from behind
+the rock the strangest man the travelers had ever seen.
+
+He was quite short and stout and had a big head, which was flat at the
+top and supported by a thick neck full of wrinkles. But he had no arms
+at all, and, seeing this, the Scarecrow did not fear that so helpless a
+creature could prevent them from climbing the hill. So he said, “I’m
+sorry not to do as you wish, but we must pass over your hill whether
+you like it or not,” and he walked boldly forward.
+
+As quick as lightning the man’s head shot forward and his neck
+stretched out until the top of the head, where it was flat, struck the
+Scarecrow in the middle and sent him tumbling, over and over, down the
+hill. Almost as quickly as it came the head went back to the body, and
+the man laughed harshly as he said, “It isn’t as easy as you think!”
+
+A chorus of boisterous laughter came from the other rocks, and Dorothy
+saw hundreds of the armless Hammer-Heads upon the hillside, one behind
+every rock.
+
+The Lion became quite angry at the laughter caused by the Scarecrow’s
+mishap, and giving a loud roar that echoed like thunder, he dashed up
+the hill.
+
+Again a head shot swiftly out, and the great Lion went rolling down the
+hill as if he had been struck by a cannon ball.
+
+Dorothy ran down and helped the Scarecrow to his feet, and the Lion
+came up to her, feeling rather bruised and sore, and said, “It is
+useless to fight people with shooting heads; no one can withstand
+them.”
+
+“What can we do, then?” she asked.
+
+“Call the Winged Monkeys,” suggested the Tin Woodman. “You have still
+the right to command them once more.”
+
+“Very well,” she answered, and putting on the Golden Cap she uttered
+the magic words. The Monkeys were as prompt as ever, and in a few
+moments the entire band stood before her.
+
+“What are your commands?” inquired the King of the Monkeys, bowing low.
+
+“Carry us over the hill to the country of the Quadlings,” answered the
+girl.
+
+“It shall be done,” said the King, and at once the Winged Monkeys
+caught the four travelers and Toto up in their arms and flew away with
+them. As they passed over the hill the Hammer-Heads yelled with
+vexation, and shot their heads high in the air, but they could not
+reach the Winged Monkeys, which carried Dorothy and her comrades safely
+over the hill and set them down in the beautiful country of the
+Quadlings.
+
+“This is the last time you can summon us,” said the leader to Dorothy;
+“so good-bye and good luck to you.”
+
+“Good-bye, and thank you very much,” returned the girl; and the Monkeys
+rose into the air and were out of sight in a twinkling.
+
+The country of the Quadlings seemed rich and happy. There was field
+upon field of ripening grain, with well-paved roads running between,
+and pretty rippling brooks with strong bridges across them. The fences
+and houses and bridges were all painted bright red, just as they had
+been painted yellow in the country of the Winkies and blue in the
+country of the Munchkins. The Quadlings themselves, who were short and
+fat and looked chubby and good-natured, were dressed all in red, which
+showed bright against the green grass and the yellowing grain.
+
+The Monkeys had set them down near a farmhouse, and the four travelers
+walked up to it and knocked at the door. It was opened by the farmer’s
+wife, and when Dorothy asked for something to eat the woman gave them
+all a good dinner, with three kinds of cake and four kinds of cookies,
+and a bowl of milk for Toto.
+
+“How far is it to the Castle of Glinda?” asked the child.
+
+“It is not a great way,” answered the farmer’s wife. “Take the road to
+the South and you will soon reach it.”
+
+Thanking the good woman, they started afresh and walked by the fields
+and across the pretty bridges until they saw before them a very
+beautiful Castle. Before the gates were three young girls, dressed in
+handsome red uniforms trimmed with gold braid; and as Dorothy
+approached, one of them said to her:
+
+“Why have you come to the South Country?”
+
+“To see the Good Witch who rules here,” she answered. “Will you take me
+to her?”
+
+“Let me have your name, and I will ask Glinda if she will receive you.”
+They told who they were, and the girl soldier went into the Castle.
+After a few moments she came back to say that Dorothy and the others
+were to be admitted at once.
+
+
+
+
+Chapter XXIII
+Glinda The Good Witch Grants Dorothy’s Wish
+
+
+Before they went to see Glinda, however, they were taken to a room of
+the Castle, where Dorothy washed her face and combed her hair, and the
+Lion shook the dust out of his mane, and the Scarecrow patted himself
+into his best shape, and the Woodman polished his tin and oiled his
+joints.
+
+When they were all quite presentable they followed the soldier girl
+into a big room where the Witch Glinda sat upon a throne of rubies.
+
+She was both beautiful and young to their eyes. Her hair was a rich red
+in color and fell in flowing ringlets over her shoulders. Her dress was
+pure white but her eyes were blue, and they looked kindly upon the
+little girl.
+
+“What can I do for you, my child?” she asked.
+
+Dorothy told the Witch all her story: how the cyclone had brought her
+to the Land of Oz, how she had found her companions, and of the
+wonderful adventures they had met with.
+
+“My greatest wish now,” she added, “is to get back to Kansas, for Aunt
+Em will surely think something dreadful has happened to me, and that
+will make her put on mourning; and unless the crops are better this
+year than they were last, I am sure Uncle Henry cannot afford it.”
+
+Glinda leaned forward and kissed the sweet, upturned face of the loving
+little girl.
+
+“Bless your dear heart,” she said, “I am sure I can tell you of a way
+to get back to Kansas.” Then she added, “But, if I do, you must give me
+the Golden Cap.”
+
+“Willingly!” exclaimed Dorothy; “indeed, it is of no use to me now, and
+when you have it you can command the Winged Monkeys three times.”
+
+“And I think I shall need their service just those three times,”
+answered Glinda, smiling.
+
+Dorothy then gave her the Golden Cap, and the Witch said to the
+Scarecrow, “What will you do when Dorothy has left us?”
+
+“I will return to the Emerald City,” he replied, “for Oz has made me
+its ruler and the people like me. The only thing that worries me is how
+to cross the hill of the Hammer-Heads.”
+
+“By means of the Golden Cap I shall command the Winged Monkeys to carry
+you to the gates of the Emerald City,” said Glinda, “for it would be a
+shame to deprive the people of so wonderful a ruler.”
+
+“Am I really wonderful?” asked the Scarecrow.
+
+“You are unusual,” replied Glinda.
+
+Turning to the Tin Woodman, she asked, “What will become of you when
+Dorothy leaves this country?”
+
+He leaned on his axe and thought a moment. Then he said, “The Winkies
+were very kind to me, and wanted me to rule over them after the Wicked
+Witch died. I am fond of the Winkies, and if I could get back again to
+the Country of the West, I should like nothing better than to rule over
+them forever.”
+
+“My second command to the Winged Monkeys,” said Glinda “will be that
+they carry you safely to the land of the Winkies. Your brain may not be
+so large to look at as those of the Scarecrow, but you are really
+brighter than he is—when you are well polished—and I am sure you will
+rule the Winkies wisely and well.”
+
+Then the Witch looked at the big, shaggy Lion and asked, “When Dorothy
+has returned to her own home, what will become of you?”
+
+“Over the hill of the Hammer-Heads,” he answered, “lies a grand old
+forest, and all the beasts that live there have made me their King. If
+I could only get back to this forest, I would pass my life very happily
+there.”
+
+“My third command to the Winged Monkeys,” said Glinda, “shall be to
+carry you to your forest. Then, having used up the powers of the Golden
+Cap, I shall give it to the King of the Monkeys, that he and his band
+may thereafter be free for evermore.”
+
+The Scarecrow and the Tin Woodman and the Lion now thanked the Good
+Witch earnestly for her kindness; and Dorothy exclaimed:
+
+“You are certainly as good as you are beautiful! But you have not yet
+told me how to get back to Kansas.”
+
+“Your Silver Shoes will carry you over the desert,” replied Glinda. “If
+you had known their power you could have gone back to your Aunt Em the
+very first day you came to this country.”
+
+“But then I should not have had my wonderful brains!” cried the
+Scarecrow. “I might have passed my whole life in the farmer’s
+cornfield.”
+
+“And I should not have had my lovely heart,” said the Tin Woodman. “I
+might have stood and rusted in the forest till the end of the world.”
+
+“And I should have lived a coward forever,” declared the Lion, “and no
+beast in all the forest would have had a good word to say to me.”
+
+“This is all true,” said Dorothy, “and I am glad I was of use to these
+good friends. But now that each of them has had what he most desired,
+and each is happy in having a kingdom to rule besides, I think I should
+like to go back to Kansas.”
+
+“The Silver Shoes,” said the Good Witch, “have wonderful powers. And
+one of the most curious things about them is that they can carry you to
+any place in the world in three steps, and each step will be made in
+the wink of an eye. All you have to do is to knock the heels together
+three times and command the shoes to carry you wherever you wish to
+go.”
+
+“If that is so,” said the child joyfully, “I will ask them to carry me
+back to Kansas at once.”
+
+She threw her arms around the Lion’s neck and kissed him, patting his
+big head tenderly. Then she kissed the Tin Woodman, who was weeping in
+a way most dangerous to his joints. But she hugged the soft, stuffed
+body of the Scarecrow in her arms instead of kissing his painted face,
+and found she was crying herself at this sorrowful parting from her
+loving comrades.
+
+Glinda the Good stepped down from her ruby throne to give the little
+girl a good-bye kiss, and Dorothy thanked her for all the kindness she
+had shown to her friends and herself.
+
+Dorothy now took Toto up solemnly in her arms, and having said one last
+good-bye she clapped the heels of her shoes together three times,
+saying:
+
+“Take me home to Aunt Em!”
+
+
+Instantly she was whirling through the air, so swiftly that all she
+could see or feel was the wind whistling past her ears.
+
+The Silver Shoes took but three steps, and then she stopped so suddenly
+that she rolled over upon the grass several times before she knew where
+she was.
+
+At length, however, she sat up and looked about her.
+
+“Good gracious!” she cried.
+
+For she was sitting on the broad Kansas prairie, and just before her
+was the new farmhouse Uncle Henry built after the cyclone had carried
+away the old one. Uncle Henry was milking the cows in the barnyard, and
+Toto had jumped out of her arms and was running toward the barn,
+barking furiously.
+
+Dorothy stood up and found she was in her stocking-feet. For the Silver
+Shoes had fallen off in her flight through the air, and were lost
+forever in the desert.
+
+
+
+
+Chapter XXIV
+Home Again
+
+
+Aunt Em had just come out of the house to water the cabbages when she
+looked up and saw Dorothy running toward her.
+
+“My darling child!” she cried, folding the little girl in her arms and
+covering her face with kisses. “Where in the world did you come from?”
+
+“From the Land of Oz,” said Dorothy gravely. “And here is Toto, too.
+And oh, Aunt Em! I’m so glad to be at home again!”
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK THE WONDERFUL WIZARD OF OZ ***
+
+***** This file should be named 55-0.txt or 55-0.zip *****
+This and all associated files of various formats will be found in:
+    https://www.gutenberg.org/5/55/
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the
+United States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away--you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you will have to check the laws of the country where
+  you are located before using this eBook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that:
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg-tm trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+Section 3. Information about the Project Gutenberg Literary
+Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation's website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without
+widespread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org
+
+This website includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/examples/ordered_wordcount/wordcount.py
+++ b/examples/ordered_wordcount/wordcount.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 
 def wordcount(filename, save_name):
     """Return number of words in file."""
+    print(">> wordcount() <<")
 
     with open(filename, "r") as f:
         data = f.read()


### PR DESCRIPTION
Clean up the ordered word count example so it can actually run. Added the missing text files needed for the example. Added a Docker compose file to easily run a RabbitMQ broker which is used by zambeze.